### PR TITLE
update to 0.14.0 compiler release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Zig
       uses: korandoru/setup-zig@v1
       with:
-        zig-version: 0.13.0
+        zig-version: 0.14.0
 
     - name: Build
       run: zig build
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Zig
       uses: korandoru/setup-zig@v1
       with:
-        zig-version: 0.13.0
+        zig-version: 0.14.0
 
     - name: Lint
       run: zig fmt --check src/*.zig
@@ -42,7 +42,7 @@ jobs:
     - name: Set up Zig
       uses: korandoru/setup-zig@v1
       with:
-        zig-version: 0.13.0
+        zig-version: 0.14.0
 
     - name: Test
       run: zig build test --summary all

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # ssz.zig
 A [Zig](https://ziglang.org) implementation of the [SSZ serialization protocol](https://github.com/ethereum/eth2.0-specs/blob/dev/ssz/simple-serialize.md).
 
- Tested with zig 0.13.0.
+ Tested with zig 0.14.0.
 
 ## Serialization
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,6 @@
 .{
-    .name = "ssz.zig",
+    .name = .ssz,
+    .fingerprint = 0x1d34bd0ceb1dfc2d,
     .version = "0.0.3",
     .paths = .{""},
 }


### PR DESCRIPTION
The next compiler version changes the capitalization of the `@typeInfo` enum tags, so have the PR ready to merge when the next version of the compiler is released.

To be merged, this still needs to:

 * [x] Update the README with the right compiler version
 * [ ] Update the `build.zig.zon` with the same compiler version
 * [x] Update the CI with that compiler version, the tests will fail until then