### PR TITLE
fix: (de)serialization of varialbe size arrays inside structs

### DIFF
--- a/src/lib.zig
+++ b/src/lib.zig
@@ -25,7 +25,7 @@ pub fn serializedFixedSize(comptime T: type) !usize {
             // or should we just throw error for all of pointer
             else => serializedFixedSize(info.pointer.child),
         },
-        .optional => error.NoSerializedSizeAvailable,
+        .optional => error.NoSerializedFixedSizeAvailable,
         .null => @as(usize, 0),
         .@"struct" => |str| size: {
             var size: usize = 0;
@@ -34,7 +34,7 @@ pub fn serializedFixedSize(comptime T: type) !usize {
             }
             break :size size;
         },
-        else => error.NoSerializedSizeAvailable,
+        else => error.NoSerializedFixedSizeAvailable,
     };
 }
 

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -209,12 +209,12 @@ pub fn serialize(comptime T: type, data: T, l: *ArrayList(u8)) !void {
         },
         .@"struct" => {
             // First pass, accumulate the fixed sizes
-            var var_start: usize = 0;
+            comptime var var_start = 0;
             inline for (info.@"struct".fields) |field| {
                 if (@typeInfo(field.type) == .int or @typeInfo(field.type) == .bool) {
                     var_start += @sizeOf(field.type);
-                } else if (try isFixedSizeObject(field.type)) {
-                    var_start += try serializedFixedSize(field.type);
+                } else if (try comptime isFixedSizeObject(field.type)) {
+                    var_start += try comptime serializedFixedSize(field.type);
                 } else {
                     var_start += 4;
                 }

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -19,7 +19,7 @@ pub fn serializedFixedSize(comptime T: type) !usize {
     const info = @typeInfo(T);
     return switch (info) {
         .int => @sizeOf(T),
-        .array => info.len * serializedFixedSize(info.array.child),
+        .array => info.array.len * try serializedFixedSize(info.array.child),
         .pointer => switch (info.pointer.size) {
             .slice => error.NoSerializedFixedSizeAvailable,
             // or should we just throw error for all of pointer
@@ -214,7 +214,7 @@ pub fn serialize(comptime T: type, data: T, l: *ArrayList(u8)) !void {
                 if (@typeInfo(field.type) == .int or @typeInfo(field.type) == .bool) {
                     var_start += @sizeOf(field.type);
                 } else if (try isFixedSizeObject(field.type)) {
-                    var_start += try serializedSize(field.type, @field(data, field.name));
+                    var_start += try serializedFixedSize(field.type);
                 } else {
                     var_start += 4;
                 }

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -421,7 +421,7 @@ pub fn deserialize(comptime T: type, serialized: []const u8, out: *T, allocator:
             // and write down the start offset of each variable-sized
             // field.
             var i: usize = 0;
-            var variable_field_index: usize = 0;
+            comptime var variable_field_index = 0;
             inline for (info.@"struct".fields) |field| {
                 switch (@typeInfo(field.type)) {
                     .bool, .int => {
@@ -430,7 +430,7 @@ pub fn deserialize(comptime T: type, serialized: []const u8, out: *T, allocator:
                         i += @sizeOf(field.type);
                     },
                     else => {
-                        if (try isFixedSizeObject(field.type)) {
+                        if (try comptime isFixedSizeObject(field.type)) {
                             // Direct deserialize
                             const field_serialized_size = try serializedFixedSize(field.type);
                             try deserialize(field.type, serialized[i .. i + field_serialized_size], &@field(out.*, field.name), allocator);

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -212,12 +212,14 @@ pub fn serialize(comptime T: type, data: T, l: *ArrayList(u8)) !void {
             // First pass, accumulate the fixed sizes
             comptime var var_start = 0;
             inline for (info.@"struct".fields) |field| {
-                if (@typeInfo(field.type) == .int or @typeInfo(field.type) == .bool) {
-                    var_start += @sizeOf(field.type);
-                } else if (try comptime isFixedSizeObject(field.type)) {
-                    var_start += try comptime serializedFixedSize(field.type);
-                } else {
-                    var_start += 4;
+                comptime {
+                    if (@typeInfo(field.type) == .int or @typeInfo(field.type) == .bool) {
+                        var_start += @sizeOf(field.type);
+                    } else if (try isFixedSizeObject(field.type)) {
+                        var_start += try serializedFixedSize(field.type);
+                    } else {
+                        var_start += 4;
+                    }
                 }
             }
 

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -89,6 +89,7 @@ pub fn isFixedSizeObject(comptime T: type) !bool {
                 return false;
             }
         },
+        .optional => return false,
         .pointer => |ptr| switch (ptr.size) {
             .many, .slice, .c => return false,
             .one => return isFixedSizeObject(info.pointer.child),

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -310,7 +310,7 @@ pub fn deserialize(comptime T: type, serialized: []const u8, out: *T, allocator:
                 const U = info.array.child;
                 if (try isFixedSizeObject(U)) {
                     comptime var i = 0;
-                    const pitch = @sizeOf(U);
+                    const pitch = try comptime serializedFixedSize(U);
                     inline while (i < out.len) : (i += pitch) {
                         try deserialize(U, serialized[i * pitch .. (i + 1) * pitch], &out[i], allocator);
                     }

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -447,7 +447,7 @@ pub fn deserialize(comptime T: type, serialized: []const u8, out: *T, allocator:
 
             // Second pass, deserialize each variable-sized value
             // now that their offset is known.
-            var last_index: usize = 0;
+            comptime var last_index = 0;
             inline for (info.@"struct".fields) |field| {
                 // comptime fields are currently not supported, and it's not even
                 // certain that they can ever be without a change in the language.
@@ -455,7 +455,7 @@ pub fn deserialize(comptime T: type, serialized: []const u8, out: *T, allocator:
 
                 switch (@typeInfo(field.type)) {
                     .bool, .int => {}, // covered by the previous pass
-                    else => if (!try isFixedSizeObject(field.type)) {
+                    else => if (!try comptime isFixedSizeObject(field.type)) {
                         const end = if (last_index == n_var_fields - 1) serialized.len else indices[last_index + 1];
                         try deserialize(field.type, serialized[indices[last_index]..end], &@field(out.*, field.name), allocator);
                         last_index += 1;

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -786,7 +786,11 @@ test "fixed/variable size arrays" {
     };
     var serialized_block = std.ArrayList(u8).init(std.testing.allocator);
     defer serialized_block.deinit();
-    try serialize(FixedBlockBody, fixed_signed_block.message.body, &serialized_block);
+    try serialize(FixedSignedBlock, fixed_signed_block, &serialized_block);
+    // verified on an equivalent nodejs container implementation
+    const expected_serialized_fix_block = [_]u8{ 9, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 199, 128, 9, 253, 240, 127, 197, 106, 17, 241, 34, 55, 6, 88, 163, 83, 170, 165, 66, 237, 99, 228, 76, 75, 193, 95, 244, 205, 16, 90, 179, 60, 81, 12, 244, 147, 45, 160, 28, 192, 208, 78, 159, 151, 165, 43, 244, 44, 103, 197, 231, 128, 122, 15, 182, 90, 109, 10, 229, 68, 229, 60, 50, 231, 9, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 };
+    try expect(std.mem.eql(u8, serialized_block.items, expected_serialized_fix_block[0..]));
+
     std.debug.print("serialized fixed_signed_block ({d}) {any}", .{
         serialized_block.items.len,
         serialized_block.items,

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -196,47 +196,47 @@ test "(de)serializes a structure with variable fields" {
 //     try std.testing.expectEqual(deserialized.company, null);
 // }
 
-// test "serializes an optional object" {
-//     const null_or_string: ?[]const u8 = null;
-//     var list = ArrayList(u8).init(std.testing.allocator);
-//     defer list.deinit();
-//     try serialize(@TypeOf(null_or_string), null_or_string, &list);
-//     try expect(list.items.len == 1);
-// }
+test "serializes an optional object" {
+    const null_or_string: ?[]const u8 = null;
+    var list = ArrayList(u8).init(std.testing.allocator);
+    defer list.deinit();
+    try serialize(@TypeOf(null_or_string), null_or_string, &list);
+    try expect(list.items.len == 1);
+}
 
-// test "serializes a union" {
-//     const Payload = union(enum) {
-//         int: u64,
-//         boolean: bool,
-//     };
+test "serializes a union" {
+    const Payload = union(enum) {
+        int: u64,
+        boolean: bool,
+    };
 
-//     var list = ArrayList(u8).init(std.testing.allocator);
-//     defer list.deinit();
-//     const exp = [_]u8{ 0, 210, 4, 0, 0, 0, 0, 0, 0 };
-//     try serialize(Payload, Payload{ .int = 1234 }, &list);
-//     try expect(std.mem.eql(u8, list.items, exp[0..]));
+    var list = ArrayList(u8).init(std.testing.allocator);
+    defer list.deinit();
+    const exp = [_]u8{ 0, 210, 4, 0, 0, 0, 0, 0, 0 };
+    try serialize(Payload, Payload{ .int = 1234 }, &list);
+    try expect(std.mem.eql(u8, list.items, exp[0..]));
 
-//     var list2 = ArrayList(u8).init(std.testing.allocator);
-//     defer list2.deinit();
-//     const exp2 = [_]u8{ 1, 1 };
-//     try serialize(Payload, Payload{ .boolean = true }, &list2);
-//     try expect(std.mem.eql(u8, list2.items, exp2[0..]));
+    var list2 = ArrayList(u8).init(std.testing.allocator);
+    defer list2.deinit();
+    const exp2 = [_]u8{ 1, 1 };
+    try serialize(Payload, Payload{ .boolean = true }, &list2);
+    try expect(std.mem.eql(u8, list2.items, exp2[0..]));
 
-//     // Make sure that the code won't try to serialize untagged
-//     // payloads.
-//     const UnTaggedPayload = union {
-//         int: u64,
-//         boolean: bool,
-//     };
+    // Make sure that the code won't try to serialize untagged
+    // payloads.
+    const UnTaggedPayload = union {
+        int: u64,
+        boolean: bool,
+    };
 
-//     var list3 = ArrayList(u8).init(std.testing.allocator);
-//     defer list3.deinit();
-//     if (serialize(UnTaggedPayload, UnTaggedPayload{ .boolean = false }, &list3)) {
-//         @panic("didn't catch error");
-//     } else |err| switch (err) {
-//         error.UnionIsNotTagged => {},
-//     }
-// }
+    var list3 = ArrayList(u8).init(std.testing.allocator);
+    defer list3.deinit();
+    if (serialize(UnTaggedPayload, UnTaggedPayload{ .boolean = false }, &list3)) {
+        @panic("didn't catch error");
+    } else |err| switch (err) {
+        error.UnionIsNotTagged => {},
+    }
+}
 
 test "(de)serializes a type with a custom serialization method" {
     const MyCustomSerializingType = struct {
@@ -443,20 +443,20 @@ test "serialize/deserialize a u256" {
     try expect(std.mem.eql(u8, data[0..], output[0..]));
 }
 
-// test "(de)serialize a .One pointer in a struct" {
-//     var a: u32 = 1;
-//     const b = .{
-//         .a = &a,
-//     };
+test "(de)serialize a .One pointer in a struct" {
+    var a: u32 = 1;
+    const b = .{
+        .a = &a,
+    };
 
-//     var list = ArrayList(u8).init(std.testing.allocator);
-//     defer list.deinit();
-//     try serialize(@TypeOf(b), b, &list);
-//     var c_val: u32 = undefined;
-//     var c: @TypeOf(b) = .{ .a = &c_val };
-//     try deserialize(@TypeOf(b), list.items, &c, std.testing.allocator);
-//     std.testing.allocator.destroy(c.a);
-// }
+    var list = ArrayList(u8).init(std.testing.allocator);
+    defer list.deinit();
+    try serialize(@TypeOf(b), b, &list);
+    var c_val: u32 = undefined;
+    var c: @TypeOf(b) = .{ .a = &c_val };
+    try deserialize(@TypeOf(b), list.items, &c, std.testing.allocator);
+    std.testing.allocator.destroy(c.a);
+}
 
 test "(de)serialize a slice of structs" {
     var list = ArrayList(u8).init(std.testing.allocator);

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -168,75 +168,75 @@ test "(de)serializes a structure with variable fields" {
     try deserialize(@TypeOf(data), list.items, &out, null);
 }
 
-test "serializes a structure with optional fields" {
-    const Employee = struct {
-        name: ?[]const u8,
-        age: u8,
-        company: ?[]const u8,
-    };
-    const data: Employee = .{
-        .name = "James",
-        .age = @as(u8, 32),
-        .company = null,
-    };
+// test "serializes a structure with optional fields" {
+//     const Employee = struct {
+//         name: ?[]const u8,
+//         age: u8,
+//         company: ?[]const u8,
+//     };
+//     const data: Employee = .{
+//         .name = "James",
+//         .age = @as(u8, 32),
+//         .company = null,
+//     };
 
-    const serialized_data = [_]u8{ 9, 0, 0, 0, 32, 15, 0, 0, 0, 1, 74, 97, 109, 101, 115, 0 };
+//     const serialized_data = [_]u8{ 9, 0, 0, 0, 32, 15, 0, 0, 0, 1, 74, 97, 109, 101, 115, 0 };
 
-    var list = ArrayList(u8).init(std.testing.allocator);
-    defer list.deinit();
-    try serialize(@TypeOf(data), data, &list);
-    try expect(std.mem.eql(u8, list.items, serialized_data[0..]));
+//     var list = ArrayList(u8).init(std.testing.allocator);
+//     defer list.deinit();
+//     try serialize(@TypeOf(data), data, &list);
+//     try expect(std.mem.eql(u8, list.items, serialized_data[0..]));
 
-    var deserialized: Employee = undefined;
-    try deserialize(Employee, list.items, &deserialized, null);
-    // only available in >=0.11
-    // try std.testing.expectEqualDeep(data, deserialized);
-    try expect(std.mem.eql(u8, data.name.?, deserialized.name.?));
-    try std.testing.expectEqual(data.age, deserialized.age);
-    try std.testing.expectEqual(deserialized.company, null);
-}
+//     var deserialized: Employee = undefined;
+//     try deserialize(Employee, list.items, &deserialized, null);
+//     // only available in >=0.11
+//     // try std.testing.expectEqualDeep(data, deserialized);
+//     try expect(std.mem.eql(u8, data.name.?, deserialized.name.?));
+//     try std.testing.expectEqual(data.age, deserialized.age);
+//     try std.testing.expectEqual(deserialized.company, null);
+// }
 
-test "serializes an optional object" {
-    const null_or_string: ?[]const u8 = null;
-    var list = ArrayList(u8).init(std.testing.allocator);
-    defer list.deinit();
-    try serialize(@TypeOf(null_or_string), null_or_string, &list);
-    try expect(list.items.len == 1);
-}
+// test "serializes an optional object" {
+//     const null_or_string: ?[]const u8 = null;
+//     var list = ArrayList(u8).init(std.testing.allocator);
+//     defer list.deinit();
+//     try serialize(@TypeOf(null_or_string), null_or_string, &list);
+//     try expect(list.items.len == 1);
+// }
 
-test "serializes a union" {
-    const Payload = union(enum) {
-        int: u64,
-        boolean: bool,
-    };
+// test "serializes a union" {
+//     const Payload = union(enum) {
+//         int: u64,
+//         boolean: bool,
+//     };
 
-    var list = ArrayList(u8).init(std.testing.allocator);
-    defer list.deinit();
-    const exp = [_]u8{ 0, 210, 4, 0, 0, 0, 0, 0, 0 };
-    try serialize(Payload, Payload{ .int = 1234 }, &list);
-    try expect(std.mem.eql(u8, list.items, exp[0..]));
+//     var list = ArrayList(u8).init(std.testing.allocator);
+//     defer list.deinit();
+//     const exp = [_]u8{ 0, 210, 4, 0, 0, 0, 0, 0, 0 };
+//     try serialize(Payload, Payload{ .int = 1234 }, &list);
+//     try expect(std.mem.eql(u8, list.items, exp[0..]));
 
-    var list2 = ArrayList(u8).init(std.testing.allocator);
-    defer list2.deinit();
-    const exp2 = [_]u8{ 1, 1 };
-    try serialize(Payload, Payload{ .boolean = true }, &list2);
-    try expect(std.mem.eql(u8, list2.items, exp2[0..]));
+//     var list2 = ArrayList(u8).init(std.testing.allocator);
+//     defer list2.deinit();
+//     const exp2 = [_]u8{ 1, 1 };
+//     try serialize(Payload, Payload{ .boolean = true }, &list2);
+//     try expect(std.mem.eql(u8, list2.items, exp2[0..]));
 
-    // Make sure that the code won't try to serialize untagged
-    // payloads.
-    const UnTaggedPayload = union {
-        int: u64,
-        boolean: bool,
-    };
+//     // Make sure that the code won't try to serialize untagged
+//     // payloads.
+//     const UnTaggedPayload = union {
+//         int: u64,
+//         boolean: bool,
+//     };
 
-    var list3 = ArrayList(u8).init(std.testing.allocator);
-    defer list3.deinit();
-    if (serialize(UnTaggedPayload, UnTaggedPayload{ .boolean = false }, &list3)) {
-        @panic("didn't catch error");
-    } else |err| switch (err) {
-        error.UnionIsNotTagged => {},
-    }
-}
+//     var list3 = ArrayList(u8).init(std.testing.allocator);
+//     defer list3.deinit();
+//     if (serialize(UnTaggedPayload, UnTaggedPayload{ .boolean = false }, &list3)) {
+//         @panic("didn't catch error");
+//     } else |err| switch (err) {
+//         error.UnionIsNotTagged => {},
+//     }
+// }
 
 test "(de)serializes a type with a custom serialization method" {
     const MyCustomSerializingType = struct {
@@ -442,20 +442,20 @@ test "serialize/deserialize a u256" {
     try expect(std.mem.eql(u8, data[0..], output[0..]));
 }
 
-test "(de)serialize a .One pointer in a struct" {
-    var a: u32 = 1;
-    const b = .{
-        .a = &a,
-    };
+// test "(de)serialize a .One pointer in a struct" {
+//     var a: u32 = 1;
+//     const b = .{
+//         .a = &a,
+//     };
 
-    var list = ArrayList(u8).init(std.testing.allocator);
-    defer list.deinit();
-    try serialize(@TypeOf(b), b, &list);
-    var c_val: u32 = undefined;
-    var c: @TypeOf(b) = .{ .a = &c_val };
-    try deserialize(@TypeOf(b), list.items, &c, std.testing.allocator);
-    std.testing.allocator.destroy(c.a);
-}
+//     var list = ArrayList(u8).init(std.testing.allocator);
+//     defer list.deinit();
+//     try serialize(@TypeOf(b), b, &list);
+//     var c_val: u32 = undefined;
+//     var c: @TypeOf(b) = .{ .a = &c_val };
+//     try deserialize(@TypeOf(b), list.items, &c, std.testing.allocator);
+//     std.testing.allocator.destroy(c.a);
+// }
 
 test "(de)serialize a slice of structs" {
     var list = ArrayList(u8).init(std.testing.allocator);
@@ -768,12 +768,29 @@ test "fixed/variable size arrays" {
         state_root: Bytes32,
         body: FixedBlockBody,
     };
-    const FixedBeamBlock = struct {
+    const FixedSignedBlock = struct {
         message: FixedBlock,
         signature: [48]u8,
     };
-    isFixedSizeType = try isFixedSizeObject(FixedBeamBlock);
+    isFixedSizeType = try isFixedSizeObject(FixedSignedBlock);
     try expect(isFixedSizeType == true);
+    const fixed_signed_block = FixedSignedBlock{
+        .message = .{
+            .slot = 9,
+            .proposer_index = 3,
+            .parent_root = [_]u8{ 199, 128, 9, 253, 240, 127, 197, 106, 17, 241, 34, 55, 6, 88, 163, 83, 170, 165, 66, 237, 99, 228, 76, 75, 193, 95, 244, 205, 16, 90, 179, 60 },
+            .state_root = [_]u8{ 81, 12, 244, 147, 45, 160, 28, 192, 208, 78, 159, 151, 165, 43, 244, 44, 103, 197, 231, 128, 122, 15, 182, 90, 109, 10, 229, 68, 229, 60, 50, 231 },
+            .body = .{ .slot = 9, .data = [_]u8{ 1, 2, 3, 4 } },
+        },
+        .signature = [_]u8{2} ** 48,
+    };
+    var serialized_block = std.ArrayList(u8).init(std.testing.allocator);
+    defer serialized_block.deinit();
+    try serialize(FixedBlockBody, fixed_signed_block.message.body, &serialized_block);
+    std.debug.print("serialized fixed_signed_block ({d}) {any}", .{
+        serialized_block.items.len,
+        serialized_block.items,
+    });
 
     // test for nested variable structures
     const VarBlockBody = struct {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -168,33 +168,33 @@ test "(de)serializes a structure with variable fields" {
     try deserialize(@TypeOf(data), list.items, &out, null);
 }
 
-// test "serializes a structure with optional fields" {
-//     const Employee = struct {
-//         name: ?[]const u8,
-//         age: u8,
-//         company: ?[]const u8,
-//     };
-//     const data: Employee = .{
-//         .name = "James",
-//         .age = @as(u8, 32),
-//         .company = null,
-//     };
+test "serializes a structure with optional fields" {
+    const Employee = struct {
+        name: ?[]const u8,
+        age: u8,
+        company: ?[]const u8,
+    };
+    const data: Employee = .{
+        .name = "James",
+        .age = @as(u8, 32),
+        .company = null,
+    };
 
-//     const serialized_data = [_]u8{ 9, 0, 0, 0, 32, 15, 0, 0, 0, 1, 74, 97, 109, 101, 115, 0 };
+    const serialized_data = [_]u8{ 9, 0, 0, 0, 32, 15, 0, 0, 0, 1, 74, 97, 109, 101, 115, 0 };
 
-//     var list = ArrayList(u8).init(std.testing.allocator);
-//     defer list.deinit();
-//     try serialize(@TypeOf(data), data, &list);
-//     try expect(std.mem.eql(u8, list.items, serialized_data[0..]));
+    var list = ArrayList(u8).init(std.testing.allocator);
+    defer list.deinit();
+    try serialize(@TypeOf(data), data, &list);
+    try expect(std.mem.eql(u8, list.items, serialized_data[0..]));
 
-//     var deserialized: Employee = undefined;
-//     try deserialize(Employee, list.items, &deserialized, null);
-//     // only available in >=0.11
-//     // try std.testing.expectEqualDeep(data, deserialized);
-//     try expect(std.mem.eql(u8, data.name.?, deserialized.name.?));
-//     try std.testing.expectEqual(data.age, deserialized.age);
-//     try std.testing.expectEqual(deserialized.company, null);
-// }
+    var deserialized: Employee = undefined;
+    try deserialize(Employee, list.items, &deserialized, null);
+    // only available in >=0.11
+    // try std.testing.expectEqualDeep(data, deserialized);
+    try expect(std.mem.eql(u8, data.name.?, deserialized.name.?));
+    try std.testing.expectEqual(data.age, deserialized.age);
+    try std.testing.expectEqual(deserialized.company, null);
+}
 
 test "serializes an optional object" {
     const null_or_string: ?[]const u8 = null;

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -408,6 +408,7 @@ test "deserializes an invalid Vector[N] payload" {
         @panic("missed error");
     } else |err| switch (err) {
         error.IndexOutOfBounds => {},
+        error.NoSerializedFixedSizeAvailable => {},
         // NOTE: this is to be uncommented if slices start using allocators
         // else => @panic(try std.fmt.allocPrint(std.testing.allocator, "wrong type of error found, err={any}", .{err})),
     }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -408,9 +408,10 @@ test "deserializes an invalid Vector[N] payload" {
         @panic("missed error");
     } else |err| switch (err) {
         error.IndexOutOfBounds => {},
-        error.NoSerializedFixedSizeAvailable => {},
-        // NOTE: this is to be uncommented if slices start using allocators
-        // else => @panic(try std.fmt.allocPrint(std.testing.allocator, "wrong type of error found, err={any}", .{err})),
+        // catch error.NoSerializedFixedSizeAvailable, and a potential allocation error if the API
+        // for deserializing slices changes to accept an allocator. None of these errors should
+        // happen.
+        else => @panic(try std.fmt.allocPrint(std.testing.allocator, "wrong type of error found, err={any}", .{err})),
     }
 }
 

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -791,11 +791,14 @@ test "fixed/variable size arrays" {
     // verified on an equivalent nodejs container implementation
     const expected_serialized_fix_block = [_]u8{ 9, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 199, 128, 9, 253, 240, 127, 197, 106, 17, 241, 34, 55, 6, 88, 163, 83, 170, 165, 66, 237, 99, 228, 76, 75, 193, 95, 244, 205, 16, 90, 179, 60, 81, 12, 244, 147, 45, 160, 28, 192, 208, 78, 159, 151, 165, 43, 244, 44, 103, 197, 231, 128, 122, 15, 182, 90, 109, 10, 229, 68, 229, 60, 50, 231, 9, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 };
     try expect(std.mem.eql(u8, serialized_block.items, expected_serialized_fix_block[0..]));
-
-    std.debug.print("serialized fixed_signed_block ({d}) {any}", .{
+    std.debug.print("serialized fixed_signed_block ({d}) {any}\n", .{
         serialized_block.items.len,
         serialized_block.items,
     });
+
+    var deserialized_block: FixedSignedBlock = undefined;
+    try deserialize(FixedSignedBlock, serialized_block.items[0..], &deserialized_block, std.testing.allocator);
+    std.debug.print("deserialized_block {any}\n", .{deserialized_block});
 
     // test for nested variable structures
     const VarBlockBody = struct {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -408,7 +408,6 @@ test "deserializes an invalid Vector[N] payload" {
         @panic("missed error");
     } else |err| switch (err) {
         error.IndexOutOfBounds => {},
-        error.NoSerializedFixedSizeAvailable => {},
         // NOTE: this is to be uncommented if slices start using allocators
         // else => @panic(try std.fmt.allocPrint(std.testing.allocator, "wrong type of error found, err={any}", .{err})),
     }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -748,7 +748,7 @@ test "(de)serialization of Bitlist[N] when N % 8 != 0" {
     try expect(bitlist.eql(&bitlist_deser));
 }
 
-test "fixed/variable size arrays" {
+test "structs with nested fixed/variable size u8 array" {
     const Bytes32 = [32]u8;
     var isFixedSizeType = try isFixedSizeObject(Bytes32);
     try expect(isFixedSizeType == true);

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -757,7 +757,7 @@ test "fixed/variable size arrays" {
     isFixedSizeType = try isFixedSizeObject(BytesVar);
     try expect(isFixedSizeType == false);
 
-    // test for nested but fixed structures
+    // 1.1 test for nested but fixed structures
     const FixedBlockBody = struct {
         slot: u64,
         data: [4]u8,
@@ -785,22 +785,26 @@ test "fixed/variable size arrays" {
         },
         .signature = [_]u8{2} ** 48,
     };
-    var serialized_block = std.ArrayList(u8).init(std.testing.allocator);
-    defer serialized_block.deinit();
-    try serialize(FixedSignedBlock, fixed_signed_block, &serialized_block);
-    // verified on an equivalent nodejs container implementation
-    const expected_serialized_fix_block = [_]u8{ 9, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 199, 128, 9, 253, 240, 127, 197, 106, 17, 241, 34, 55, 6, 88, 163, 83, 170, 165, 66, 237, 99, 228, 76, 75, 193, 95, 244, 205, 16, 90, 179, 60, 81, 12, 244, 147, 45, 160, 28, 192, 208, 78, 159, 151, 165, 43, 244, 44, 103, 197, 231, 128, 122, 15, 182, 90, 109, 10, 229, 68, 229, 60, 50, 231, 9, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 };
-    try expect(std.mem.eql(u8, serialized_block.items, expected_serialized_fix_block[0..]));
-    std.debug.print("serialized fixed_signed_block ({d}) {any}\n", .{
-        serialized_block.items.len,
-        serialized_block.items,
-    });
+    var serialized_fixed_block = std.ArrayList(u8).init(std.testing.allocator);
+    defer serialized_fixed_block.deinit();
+    try serialize(FixedSignedBlock, fixed_signed_block, &serialized_fixed_block);
+    // 1.2 verified on an equivalent nodejs container implementation
+    const expected_serialized_fixed_block = [_]u8{ 9, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 199, 128, 9, 253, 240, 127, 197, 106, 17, 241, 34, 55, 6, 88, 163, 83, 170, 165, 66, 237, 99, 228, 76, 75, 193, 95, 244, 205, 16, 90, 179, 60, 81, 12, 244, 147, 45, 160, 28, 192, 208, 78, 159, 151, 165, 43, 244, 44, 103, 197, 231, 128, 122, 15, 182, 90, 109, 10, 229, 68, 229, 60, 50, 231, 9, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 };
+    try expect(std.mem.eql(u8, serialized_fixed_block.items, expected_serialized_fixed_block[0..]));
 
-    var deserialized_block: FixedSignedBlock = undefined;
-    try deserialize(FixedSignedBlock, serialized_block.items[0..], &deserialized_block, std.testing.allocator);
-    std.debug.print("deserialized_block {any}\n", .{deserialized_block});
+    var deserialized_fixed_block: FixedSignedBlock = undefined;
+    try deserialize(FixedSignedBlock, serialized_fixed_block.items[0..], &deserialized_fixed_block, std.testing.allocator);
 
-    // test for nested variable structures
+    // 1.3 match the individual fields
+    try expect(std.mem.eql(u8, fixed_signed_block.signature[0..], deserialized_fixed_block.signature[0..]));
+    try expect(fixed_signed_block.message.slot == deserialized_fixed_block.message.slot);
+    try expect(fixed_signed_block.message.proposer_index == deserialized_fixed_block.message.proposer_index);
+    try expect(std.mem.eql(u8, fixed_signed_block.message.parent_root[0..], deserialized_fixed_block.message.parent_root[0..]));
+    try expect(std.mem.eql(u8, fixed_signed_block.message.state_root[0..], deserialized_fixed_block.message.state_root[0..]));
+    try expect(fixed_signed_block.message.body.slot == deserialized_fixed_block.message.body.slot);
+    try expect(std.mem.eql(u8, fixed_signed_block.message.body.data[0..], deserialized_fixed_block.message.body.data[0..]));
+
+    // 2.1 test for nested variable structures
     const VarBlockBody = struct {
         slot: u64,
         data: []u8,
@@ -812,10 +816,43 @@ test "fixed/variable size arrays" {
         state_root: Bytes32,
         body: VarBlockBody,
     };
-    const VarBeamBlock = struct {
+    const VarSignedBlock = struct {
         message: VarBlock,
         signature: [48]u8,
     };
-    isFixedSizeType = try isFixedSizeObject(VarBeamBlock);
+    isFixedSizeType = try isFixedSizeObject(VarSignedBlock);
     try expect(isFixedSizeType == false);
+
+    var varData = [_]u8{ 1, 2, 3, 4 };
+    const var_signed_block = VarSignedBlock{
+        .message = .{
+            .slot = 9,
+            .proposer_index = 3,
+            .parent_root = [_]u8{ 199, 128, 9, 253, 240, 127, 197, 106, 17, 241, 34, 55, 6, 88, 163, 83, 170, 165, 66, 237, 99, 228, 76, 75, 193, 95, 244, 205, 16, 90, 179, 60 },
+            .state_root = [_]u8{ 81, 12, 244, 147, 45, 160, 28, 192, 208, 78, 159, 151, 165, 43, 244, 44, 103, 197, 231, 128, 122, 15, 182, 90, 109, 10, 229, 68, 229, 60, 50, 231 },
+            .body = .{ .slot = 9, .data = &varData },
+        },
+        .signature = [_]u8{2} ** 48,
+    };
+
+    var serialized_var_block = std.ArrayList(u8).init(std.testing.allocator);
+    defer serialized_var_block.deinit();
+    try serialize(VarSignedBlock, var_signed_block, &serialized_var_block);
+    // 2.2 verified on an equivalent nodejs container implementation
+    const expected_serialized_var_block = [_]u8{ 52, 0, 0, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 9, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 199, 128, 9, 253, 240, 127, 197, 106, 17, 241, 34, 55, 6, 88, 163, 83, 170, 165, 66, 237, 99, 228, 76, 75, 193, 95, 244, 205, 16, 90, 179, 60, 81, 12, 244, 147, 45, 160, 28, 192, 208, 78, 159, 151, 165, 43, 244, 44, 103, 197, 231, 128, 122, 15, 182, 90, 109, 10, 229, 68, 229, 60, 50, 231, 84, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0, 12, 0, 0, 0, 1, 2, 3, 4 };
+    try expect(std.mem.eql(u8, serialized_var_block.items, expected_serialized_var_block[0..]));
+
+    var deserialized_var_block: VarSignedBlock = undefined;
+    try deserialize(VarSignedBlock, serialized_var_block.items[0..], &deserialized_var_block, std.testing.allocator);
+    // how should the things to be de-inited accumulated?
+    defer std.testing.allocator.free(deserialized_var_block.message.body.data);
+
+    // 2.3 match the individual fields
+    try expect(std.mem.eql(u8, var_signed_block.signature[0..], deserialized_var_block.signature[0..]));
+    try expect(var_signed_block.message.slot == deserialized_var_block.message.slot);
+    try expect(var_signed_block.message.proposer_index == deserialized_var_block.message.proposer_index);
+    try expect(std.mem.eql(u8, var_signed_block.message.parent_root[0..], deserialized_var_block.message.parent_root[0..]));
+    try expect(std.mem.eql(u8, var_signed_block.message.state_root[0..], deserialized_var_block.message.state_root[0..]));
+    try expect(var_signed_block.message.body.slot == deserialized_var_block.message.body.slot);
+    try expect(std.mem.eql(u8, var_signed_block.message.body.data[0..], deserialized_var_block.message.body.data[0..]));
 }


### PR DESCRIPTION
fixed fields were also treated as variable in struct serialization/deserilzation

TODO
 - [x] fix deserilization as well
 - [x] fix previously breaking test cases