### PR TITLE
Fix SSZ List/Bitlist type detection and tree root calculation

### DIFF
--- a/src/lib.zig
+++ b/src/lib.zig
@@ -133,6 +133,11 @@ fn isBitlistType(comptime T: type) bool {
 
 /// Returns true if an object is of fixed size
 pub fn isFixedSizeObject(comptime T: type) !bool {
+    // List and Bitlist are variable-length containers per SSZ spec
+    if (comptime isListType(T) or isBitlistType(T)) {
+        return false;
+    }
+    
     const info = @typeInfo(T);
     switch (info) {
         .bool, .int, .null => return true,

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -42,7 +42,7 @@ pub fn serializedFixedSize(comptime T: type) !usize {
 // the code serializing of variable-size objects can
 // determine the offset to the next object.
 pub fn serializedSize(comptime T: type, data: T) !usize {
-    // Check for custom serializedSize method first
+    // Check for custom serializedSize method first for List types
     if (comptime std.meta.hasFn(T, "serializedSize")) {
         return data.serializedSize();
     }

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -742,11 +742,9 @@ fn packBits(bits: []const bool, l: *ArrayList(u8)) ![]chunk {
 }
 
 pub fn hashTreeRoot(comptime T: type, value: T, out: *[32]u8, allctr: Allocator) !void {
-    if (comptime utils.isListType(T)) {
-        return utils.hashTreeRootList(T, value, out, allctr);
-    }
-    if (comptime utils.isBitlistType(T)) {
-        return utils.hashTreeRootBitlist(T, value, out, allctr);
+    // Check if type has its own hashTreeRoot method at compile time
+    if (comptime std.meta.hasFn(T, "hashTreeRoot")) {
+        return value.hashTreeRoot(out, allctr);
     }
 
     const type_info = @typeInfo(T);

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -10,7 +10,7 @@ const hashes_of_zero = @import("./zeros.zig").hashes_of_zero;
 const Allocator = std.mem.Allocator;
 
 /// Number of bytes per chunk.
-pub const BYTES_PER_CHUNK = 32;
+const BYTES_PER_CHUNK = 32;
 
 /// Number of bytes per serialized length offset.
 const BYTES_PER_LENGTH_OFFSET = 4;
@@ -502,6 +502,16 @@ pub fn deserialize(comptime T: type, serialized: []const u8, out: *T, allocator:
     }
 }
 
+pub fn mixInLength2(root: [32]u8, length: usize, out: *[32]u8) void {
+    var hasher = sha256.init(sha256.Options{});
+    hasher.update(root[0..]);
+
+    var tmp = [_]u8{0} ** 32;
+    std.mem.writeInt(@TypeOf(length), tmp[0..@sizeOf(@TypeOf(length))], length, std.builtin.Endian.little);
+    hasher.update(tmp[0..]);
+    hasher.final(out[0..]);
+}
+
 fn mixInLength(root: [32]u8, length: [32]u8, out: *[32]u8) void {
     var hasher = sha256.init(sha256.Options{});
     hasher.update(root[0..]);
@@ -563,8 +573,154 @@ pub fn chunkCount(comptime T: type) usize {
     }
 }
 
-pub const chunk = [BYTES_PER_CHUNK]u8;
-pub const zero_chunk: chunk = [_]u8{0} ** BYTES_PER_CHUNK;
+const chunk = [BYTES_PER_CHUNK]u8;
+const zero_chunk: chunk = [_]u8{0} ** BYTES_PER_CHUNK;
+
+pub fn pack(comptime T: type, values: T, l: *ArrayList(u8)) ![]chunk {
+    try serialize(T, values, l);
+    const padding_size = (BYTES_PER_CHUNK - l.items.len % BYTES_PER_CHUNK) % BYTES_PER_CHUNK;
+    _ = try l.writer().write(zero_chunk[0..padding_size]);
+    return std.mem.bytesAsSlice(chunk, l.items);
+}
+
+test "pack u32" {
+    var expected: [32]u8 = undefined;
+    var list = ArrayList(u8).init(std.testing.allocator);
+    defer list.deinit();
+    const out = try pack(u32, 0xdeadbeef, &list);
+
+    _ = try std.fmt.hexToBytes(expected[0..], "efbeadde00000000000000000000000000000000000000000000000000000000");
+
+    try std.testing.expect(std.mem.eql(u8, out[0][0..], expected[0..]));
+}
+
+test "pack bool" {
+    var expected: [32]u8 = undefined;
+    var list = ArrayList(u8).init(std.testing.allocator);
+    defer list.deinit();
+    const out = try pack(bool, true, &list);
+
+    _ = try std.fmt.hexToBytes(expected[0..], "0100000000000000000000000000000000000000000000000000000000000000");
+
+    try std.testing.expect(std.mem.eql(u8, out[0][0..], expected[0..]));
+}
+
+test "pack string" {
+    var expected: [128]u8 = undefined;
+    var list = ArrayList(u8).init(std.testing.allocator);
+    defer list.deinit();
+    const out = try pack([]const u8, "a" ** 100, &list);
+
+    _ = try std.fmt.hexToBytes(expected[0..], "6161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616100000000000000000000000000000000000000000000000000000000");
+
+    try std.testing.expect(expected.len == out.len * out[0].len);
+    try std.testing.expect(std.mem.eql(u8, out[0][0..], expected[0..32]));
+    try std.testing.expect(std.mem.eql(u8, out[1][0..], expected[32..64]));
+    try std.testing.expect(std.mem.eql(u8, out[2][0..], expected[64..96]));
+    try std.testing.expect(std.mem.eql(u8, out[3][0..], expected[96..]));
+}
+
+// merkleize recursively calculates the root hash of a Merkle tree.
+pub fn merkleize(hasher: type, chunks: []chunk, limit: ?usize, out: *[32]u8) anyerror!void {
+    // Calculate the number of chunks to be padded, check the limit
+    if (limit != null and chunks.len > limit.?) {
+        return error.ChunkSizeExceedsLimit;
+    }
+    const power = limit orelse chunks.len;
+    const size = if (power > 0) try std.math.ceilPowerOfTwo(usize, power) else 0;
+
+    // Perform the merkelization
+    switch (size) {
+        0 => std.mem.copyForwards(u8, out.*[0..], zero_chunk[0..]),
+        1 => std.mem.copyForwards(u8, out.*[0..], chunks[0][0..]),
+        else => {
+            // Merkleize the left side. If the number of chunks
+            // isn't enough to fill the entire width, complete
+            // with zeroes.
+            var digest = hasher.init(hasher.Options{});
+            var buf: [32]u8 = undefined;
+            const split = if (size / 2 < chunks.len) size / 2 else chunks.len;
+            try merkleize(hasher, chunks[0..split], size / 2, &buf);
+            digest.update(buf[0..]);
+
+            // Merkleize the right side. If the number of chunks only
+            // covers the first half, directly input the hashed zero-
+            // filled subtrie.
+            if (size / 2 < chunks.len) {
+                try merkleize(hasher, chunks[size / 2 ..], size / 2, &buf);
+                digest.update(buf[0..]);
+            } else digest.update(hashes_of_zero[size / 2 - 1][0..]);
+            digest.final(out);
+        },
+    }
+}
+
+test "merkleize an empty slice" {
+    var list = ArrayList(u8).init(std.testing.allocator);
+    defer list.deinit();
+    const chunks = &[0][32]u8{};
+    var out: [32]u8 = undefined;
+    try merkleize(sha256, chunks, null, &out);
+    try std.testing.expect(std.mem.eql(u8, out[0..], zero_chunk[0..]));
+}
+
+test "merkleize a string" {
+    var list = ArrayList(u8).init(std.testing.allocator);
+    defer list.deinit();
+    const chunks = try pack([]const u8, "a" ** 100, &list);
+    var out: [32]u8 = undefined;
+    try merkleize(sha256, chunks, null, &out);
+    // Build the expected tree
+    const leaf1 = [_]u8{0x61} ** 32; // "0xaaaaa....aa" 32 times
+    var leaf2: [32]u8 = [_]u8{0x61} ** 4 ++ [_]u8{0} ** 28;
+    var root: [32]u8 = undefined;
+    var internal_left: [32]u8 = undefined;
+    var internal_right: [32]u8 = undefined;
+    var hasher = sha256.init(sha256.Options{});
+    hasher.update(leaf1[0..]);
+    hasher.update(leaf1[0..]);
+    hasher.final(&internal_left);
+    hasher = sha256.init(sha256.Options{});
+    hasher.update(leaf1[0..]);
+    hasher.update(leaf2[0..]);
+    hasher.final(&internal_right);
+    hasher = sha256.init(sha256.Options{});
+    hasher.update(internal_left[0..]);
+    hasher.update(internal_right[0..]);
+    hasher.final(&root);
+
+    try std.testing.expect(std.mem.eql(u8, out[0..], root[0..]));
+}
+
+test "merkleize a boolean" {
+    var list = ArrayList(u8).init(std.testing.allocator);
+    defer list.deinit();
+
+    var chunks = try pack(bool, false, &list);
+    var expected = [_]u8{0} ** BYTES_PER_CHUNK;
+    var out: [BYTES_PER_CHUNK]u8 = undefined;
+    try merkleize(sha256, chunks, null, &out);
+
+    try std.testing.expect(std.mem.eql(u8, out[0..], expected[0..]));
+
+    var list2 = ArrayList(u8).init(std.testing.allocator);
+    defer list2.deinit();
+
+    chunks = try pack(bool, true, &list2);
+    expected[0] = 1;
+    try merkleize(sha256, chunks, null, &out);
+    try std.testing.expect(std.mem.eql(u8, out[0..], expected[0..]));
+}
+
+test "merkleize a bytes16 vector with one element" {
+    var list = ArrayList(u8).init(std.testing.allocator);
+    defer list.deinit();
+    _ = try pack([16]u8, [_]u8{0xaa} ** 16, &list);
+    // var expected: [32]u8 = [_]u8{0xaa} ** 16 ++ [_]u8{0x00} ** 16;
+    // var out: [32]u8 = undefined;
+    // try merkleize(sha256, chunks, null, &out);
+    // try std.testing.expect(std.mem.eql(u8, out[0..], expected[0..]));
+}
 
 fn packBits(bits: []const bool, l: *ArrayList(u8)) ![]chunk {
     var byte: u8 = 0;
@@ -598,8 +754,8 @@ pub fn hashTreeRoot(comptime T: type, value: T, out: *[32]u8, allctr: Allocator)
         .int, .bool => {
             var list = ArrayList(u8).init(allctr);
             defer list.deinit();
-            const chunks = try utils.pack(T, value, &list);
-            try utils.merkleize(sha256, chunks, null, out);
+            const chunks = try pack(T, value, &list);
+            try merkleize(sha256, chunks, null, out);
         },
         .array => |a| {
             // Check if the child is a basic type. If so, return
@@ -610,14 +766,14 @@ pub fn hashTreeRoot(comptime T: type, value: T, out: *[32]u8, allctr: Allocator)
                 .int => {
                     var list = ArrayList(u8).init(allctr);
                     defer list.deinit();
-                    const chunks = try utils.pack(T, value, &list);
-                    try utils.merkleize(sha256, chunks, null, out);
+                    const chunks = try pack(T, value, &list);
+                    try merkleize(sha256, chunks, null, out);
                 },
                 .bool => {
                     var list = ArrayList(u8).init(allctr);
                     defer list.deinit();
                     const chunks = try packBits(value[0..], &list);
-                    try utils.merkleize(sha256, chunks, chunkCount(T), out);
+                    try merkleize(sha256, chunks, chunkCount(T), out);
                 },
                 .array => {
                     var chunks = ArrayList(chunk).init(allctr);
@@ -627,7 +783,7 @@ pub fn hashTreeRoot(comptime T: type, value: T, out: *[32]u8, allctr: Allocator)
                         try hashTreeRoot(@TypeOf(item), item, &tmp, allctr);
                         try chunks.append(tmp);
                     }
-                    try utils.merkleize(sha256, chunks.items, null, out);
+                    try merkleize(sha256, chunks.items, null, out);
                 },
                 else => return error.NotSupported,
             }
@@ -640,10 +796,10 @@ pub fn hashTreeRoot(comptime T: type, value: T, out: *[32]u8, allctr: Allocator)
                         .int => {
                             var list = ArrayList(u8).init(allctr);
                             defer list.deinit();
-                            const chunks = try utils.pack(T, value, &list);
+                            const chunks = try pack(T, value, &list);
                             var tmp: chunk = undefined;
-                            try utils.merkleize(sha256, chunks, null, &tmp);
-                            utils.mixInLength2(tmp, value.len, out);
+                            try merkleize(sha256, chunks, null, &tmp);
+                            mixInLength2(tmp, value.len, out);
                         },
                         // use bitlist
                         .bool => return error.UnSupportedPointerType,
@@ -656,8 +812,8 @@ pub fn hashTreeRoot(comptime T: type, value: T, out: *[32]u8, allctr: Allocator)
                                 try hashTreeRoot(@TypeOf(item), item, &tmp, allctr);
                                 try chunks.append(tmp);
                             }
-                            try utils.merkleize(sha256, chunks.items, null, &tmp);
-                            utils.mixInLength2(tmp, chunks.items.len, out);
+                            try merkleize(sha256, chunks.items, null, &tmp);
+                            mixInLength2(tmp, chunks.items.len, out);
                         },
                     }
                 },
@@ -672,7 +828,7 @@ pub fn hashTreeRoot(comptime T: type, value: T, out: *[32]u8, allctr: Allocator)
                 try hashTreeRoot(f.type, @field(value, f.name), &tmp, allctr);
                 try chunks.append(tmp);
             }
-            try utils.merkleize(sha256, chunks.items, null, out);
+            try merkleize(sha256, chunks.items, null, out);
         },
         // An optional is a union with `None` as first value.
         .optional => |opt| if (value != null) {

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -88,6 +88,12 @@ fn isListType(comptime T: type) bool {
     const type_info = @typeInfo(T);
     if (type_info != .@"struct") return false;
     
+    // Primary: check for explicit SSZ type marker
+    if (@hasDecl(T, "ssz_type_kind")) {
+        return T.ssz_type_kind == .list;
+    }
+    
+    // Fallback: structural detection
     const has_inner = comptime for (type_info.@"struct".fields) |field| {
         if (std.mem.eql(u8, field.name, "inner")) break true;
     } else false;
@@ -104,6 +110,12 @@ fn isBitlistType(comptime T: type) bool {
     const type_info = @typeInfo(T);
     if (type_info != .@"struct") return false;
     
+    // Primary: check for explicit SSZ type marker
+    if (@hasDecl(T, "ssz_type_kind")) {
+        return T.ssz_type_kind == .bitlist;
+    }
+    
+    // Fallback: structural detection
     const has_inner = comptime for (type_info.@"struct".fields) |field| {
         if (std.mem.eql(u8, field.name, "inner")) break true;
     } else false;

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -42,6 +42,14 @@ pub fn serializedFixedSize(comptime T: type) !usize {
 // the code serializing of variable-size objects can
 // determine the offset to the next object.
 pub fn serializedSize(comptime T: type, data: T) !usize {
+    // List and Bitlist should use their sszEncode to determine actual size
+    if (comptime isListType(T) or isBitlistType(T)) {
+        var temp_list = ArrayList(u8).init(std.heap.page_allocator);
+        defer temp_list.deinit();
+        try data.sszEncode(&temp_list);
+        return temp_list.items.len;
+    }
+    
     const info = @typeInfo(T);
     return switch (info) {
         .int => @sizeOf(T),

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -42,12 +42,9 @@ pub fn serializedFixedSize(comptime T: type) !usize {
 // the code serializing of variable-size objects can
 // determine the offset to the next object.
 pub fn serializedSize(comptime T: type, data: T) !usize {
-    // List and Bitlist should use their sszEncode to determine actual size
-    if (comptime utils.isListType(T) or utils.isBitlistType(T)) {
-        var temp_list = ArrayList(u8).init(std.heap.page_allocator);
-        defer temp_list.deinit();
-        try data.sszEncode(&temp_list);
-        return temp_list.items.len;
+    // Check for custom serializedSize method first
+    if (comptime std.meta.hasFn(T, "serializedSize")) {
+        return data.serializedSize();
     }
 
     const info = @typeInfo(T);

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -10,7 +10,7 @@ const hashes_of_zero = @import("./zeros.zig").hashes_of_zero;
 const Allocator = std.mem.Allocator;
 
 /// Number of bytes per chunk.
-const BYTES_PER_CHUNK = 32;
+pub const BYTES_PER_CHUNK = 32;
 
 /// Number of bytes per serialized length offset.
 const BYTES_PER_LENGTH_OFFSET = 4;
@@ -90,7 +90,7 @@ pub fn serializedSize(comptime T: type, data: T) !usize {
 
 /// Returns true if an object is of fixed size
 pub fn isFixedSizeObject(comptime T: type) !bool {
-    // List and Bitlist are variable-length containers per SSZ spec
+    // List and Bitlist are variable-length containers
     if (comptime utils.isListType(T) or utils.isBitlistType(T)) {
         return false;
     }
@@ -502,16 +502,6 @@ pub fn deserialize(comptime T: type, serialized: []const u8, out: *T, allocator:
     }
 }
 
-fn mixInLength2(root: [32]u8, length: usize, out: *[32]u8) void {
-    var hasher = sha256.init(sha256.Options{});
-    hasher.update(root[0..]);
-
-    var tmp = [_]u8{0} ** 32;
-    std.mem.writeInt(@TypeOf(length), tmp[0..@sizeOf(@TypeOf(length))], length, std.builtin.Endian.little);
-    hasher.update(tmp[0..]);
-    hasher.final(out[0..]);
-}
-
 fn mixInLength(root: [32]u8, length: [32]u8, out: *[32]u8) void {
     var hasher = sha256.init(sha256.Options{});
     hasher.update(root[0..]);
@@ -573,154 +563,8 @@ pub fn chunkCount(comptime T: type) usize {
     }
 }
 
-const chunk = [BYTES_PER_CHUNK]u8;
-const zero_chunk: chunk = [_]u8{0} ** BYTES_PER_CHUNK;
-
-fn pack(comptime T: type, values: T, l: *ArrayList(u8)) ![]chunk {
-    try serialize(T, values, l);
-    const padding_size = (BYTES_PER_CHUNK - l.items.len % BYTES_PER_CHUNK) % BYTES_PER_CHUNK;
-    _ = try l.writer().write(zero_chunk[0..padding_size]);
-    return std.mem.bytesAsSlice(chunk, l.items);
-}
-
-test "pack u32" {
-    var expected: [32]u8 = undefined;
-    var list = ArrayList(u8).init(std.testing.allocator);
-    defer list.deinit();
-    const out = try pack(u32, 0xdeadbeef, &list);
-
-    _ = try std.fmt.hexToBytes(expected[0..], "efbeadde00000000000000000000000000000000000000000000000000000000");
-
-    try std.testing.expect(std.mem.eql(u8, out[0][0..], expected[0..]));
-}
-
-test "pack bool" {
-    var expected: [32]u8 = undefined;
-    var list = ArrayList(u8).init(std.testing.allocator);
-    defer list.deinit();
-    const out = try pack(bool, true, &list);
-
-    _ = try std.fmt.hexToBytes(expected[0..], "0100000000000000000000000000000000000000000000000000000000000000");
-
-    try std.testing.expect(std.mem.eql(u8, out[0][0..], expected[0..]));
-}
-
-test "pack string" {
-    var expected: [128]u8 = undefined;
-    var list = ArrayList(u8).init(std.testing.allocator);
-    defer list.deinit();
-    const out = try pack([]const u8, "a" ** 100, &list);
-
-    _ = try std.fmt.hexToBytes(expected[0..], "6161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616100000000000000000000000000000000000000000000000000000000");
-
-    try std.testing.expect(expected.len == out.len * out[0].len);
-    try std.testing.expect(std.mem.eql(u8, out[0][0..], expected[0..32]));
-    try std.testing.expect(std.mem.eql(u8, out[1][0..], expected[32..64]));
-    try std.testing.expect(std.mem.eql(u8, out[2][0..], expected[64..96]));
-    try std.testing.expect(std.mem.eql(u8, out[3][0..], expected[96..]));
-}
-
-// merkleize recursively calculates the root hash of a Merkle tree.
-pub fn merkleize(hasher: type, chunks: []chunk, limit: ?usize, out: *[32]u8) anyerror!void {
-    // Calculate the number of chunks to be padded, check the limit
-    if (limit != null and chunks.len > limit.?) {
-        return error.ChunkSizeExceedsLimit;
-    }
-    const power = limit orelse chunks.len;
-    const size = if (power > 0) try std.math.ceilPowerOfTwo(usize, power) else 0;
-
-    // Perform the merkelization
-    switch (size) {
-        0 => std.mem.copyForwards(u8, out.*[0..], zero_chunk[0..]),
-        1 => std.mem.copyForwards(u8, out.*[0..], chunks[0][0..]),
-        else => {
-            // Merkleize the left side. If the number of chunks
-            // isn't enough to fill the entire width, complete
-            // with zeroes.
-            var digest = hasher.init(hasher.Options{});
-            var buf: [32]u8 = undefined;
-            const split = if (size / 2 < chunks.len) size / 2 else chunks.len;
-            try merkleize(hasher, chunks[0..split], size / 2, &buf);
-            digest.update(buf[0..]);
-
-            // Merkleize the right side. If the number of chunks only
-            // covers the first half, directly input the hashed zero-
-            // filled subtrie.
-            if (size / 2 < chunks.len) {
-                try merkleize(hasher, chunks[size / 2 ..], size / 2, &buf);
-                digest.update(buf[0..]);
-            } else digest.update(hashes_of_zero[size / 2 - 1][0..]);
-            digest.final(out);
-        },
-    }
-}
-
-test "merkleize an empty slice" {
-    var list = ArrayList(u8).init(std.testing.allocator);
-    defer list.deinit();
-    const chunks = &[0][32]u8{};
-    var out: [32]u8 = undefined;
-    try merkleize(sha256, chunks, null, &out);
-    try std.testing.expect(std.mem.eql(u8, out[0..], zero_chunk[0..]));
-}
-
-test "merkleize a string" {
-    var list = ArrayList(u8).init(std.testing.allocator);
-    defer list.deinit();
-    const chunks = try pack([]const u8, "a" ** 100, &list);
-    var out: [32]u8 = undefined;
-    try merkleize(sha256, chunks, null, &out);
-    // Build the expected tree
-    const leaf1 = [_]u8{0x61} ** 32; // "0xaaaaa....aa" 32 times
-    var leaf2: [32]u8 = [_]u8{0x61} ** 4 ++ [_]u8{0} ** 28;
-    var root: [32]u8 = undefined;
-    var internal_left: [32]u8 = undefined;
-    var internal_right: [32]u8 = undefined;
-    var hasher = sha256.init(sha256.Options{});
-    hasher.update(leaf1[0..]);
-    hasher.update(leaf1[0..]);
-    hasher.final(&internal_left);
-    hasher = sha256.init(sha256.Options{});
-    hasher.update(leaf1[0..]);
-    hasher.update(leaf2[0..]);
-    hasher.final(&internal_right);
-    hasher = sha256.init(sha256.Options{});
-    hasher.update(internal_left[0..]);
-    hasher.update(internal_right[0..]);
-    hasher.final(&root);
-
-    try std.testing.expect(std.mem.eql(u8, out[0..], root[0..]));
-}
-
-test "merkleize a boolean" {
-    var list = ArrayList(u8).init(std.testing.allocator);
-    defer list.deinit();
-
-    var chunks = try pack(bool, false, &list);
-    var expected = [_]u8{0} ** BYTES_PER_CHUNK;
-    var out: [BYTES_PER_CHUNK]u8 = undefined;
-    try merkleize(sha256, chunks, null, &out);
-
-    try std.testing.expect(std.mem.eql(u8, out[0..], expected[0..]));
-
-    var list2 = ArrayList(u8).init(std.testing.allocator);
-    defer list2.deinit();
-
-    chunks = try pack(bool, true, &list2);
-    expected[0] = 1;
-    try merkleize(sha256, chunks, null, &out);
-    try std.testing.expect(std.mem.eql(u8, out[0..], expected[0..]));
-}
-
-test "merkleize a bytes16 vector with one element" {
-    var list = ArrayList(u8).init(std.testing.allocator);
-    defer list.deinit();
-    _ = try pack([16]u8, [_]u8{0xaa} ** 16, &list);
-    // var expected: [32]u8 = [_]u8{0xaa} ** 16 ++ [_]u8{0x00} ** 16;
-    // var out: [32]u8 = undefined;
-    // try merkleize(sha256, chunks, null, &out);
-    // try std.testing.expect(std.mem.eql(u8, out[0..], expected[0..]));
-}
+pub const chunk = [BYTES_PER_CHUNK]u8;
+pub const zero_chunk: chunk = [_]u8{0} ** BYTES_PER_CHUNK;
 
 fn packBits(bits: []const bool, l: *ArrayList(u8)) ![]chunk {
     var byte: u8 = 0;
@@ -741,79 +585,12 @@ fn packBits(bits: []const bool, l: *ArrayList(u8)) ![]chunk {
     return std.mem.bytesAsSlice(chunk, l.items);
 }
 
-fn hashTreeRootList(comptime T: type, value: T, out: *[32]u8, allctr: Allocator) !void {
-    const slice = value.constSlice();
-
-    if (slice.len == 0) {
-        const tmp: chunk = zero_chunk;
-        mixInLength2(tmp, 0, out);
-        return;
-    }
-
-    const Item = @TypeOf(slice[0]);
-    switch (@typeInfo(Item)) {
-        .int => {
-            var list = ArrayList(u8).init(allctr);
-            defer list.deinit();
-            const chunks = try pack([]const Item, slice, &list);
-            var tmp: chunk = undefined;
-            try merkleize(sha256, chunks, null, &tmp);
-            mixInLength2(tmp, slice.len, out);
-        },
-        else => {
-            var chunks = ArrayList(chunk).init(allctr);
-            defer chunks.deinit();
-            var tmp: chunk = undefined;
-            for (slice) |item| {
-                try hashTreeRoot(Item, item, &tmp, allctr);
-                try chunks.append(tmp);
-            }
-            try merkleize(sha256, chunks.items, null, &tmp);
-            mixInLength2(tmp, slice.len, out);
-        },
-    }
-}
-
-fn hashTreeRootBitlist(comptime T: type, value: T, out: *[32]u8, allctr: Allocator) !void {
-    const bit_length = value.length;
-    if (bit_length == 0) {
-        const tmp: chunk = zero_chunk;
-        mixInLength2(tmp, 0, out);
-        return;
-    }
-
-    var list = ArrayList(u8).init(allctr);
-    defer list.deinit();
-
-    const byte_slice = value.inner.constSlice();
-    const full_bytes = bit_length / 8;
-    const remaining_bits = bit_length % 8;
-
-    if (full_bytes > 0) {
-        try list.appendSlice(byte_slice[0..full_bytes]);
-    }
-
-    if (remaining_bits > 0) {
-        const last_byte = byte_slice[full_bytes];
-        const mask = (@as(u8, 1) << @truncate(remaining_bits)) - 1;
-        try list.append(last_byte & mask);
-    }
-
-    const padding_size = (BYTES_PER_CHUNK - list.items.len % BYTES_PER_CHUNK) % BYTES_PER_CHUNK;
-    _ = try list.writer().write(zero_chunk[0..padding_size]);
-
-    const chunks = std.mem.bytesAsSlice(chunk, list.items);
-    var tmp: chunk = undefined;
-    try merkleize(sha256, chunks, null, &tmp);
-    mixInLength2(tmp, bit_length, out);
-}
-
 pub fn hashTreeRoot(comptime T: type, value: T, out: *[32]u8, allctr: Allocator) !void {
     if (comptime utils.isListType(T)) {
-        return hashTreeRootList(T, value, out, allctr);
+        return utils.hashTreeRootList(T, value, out, allctr);
     }
     if (comptime utils.isBitlistType(T)) {
-        return hashTreeRootBitlist(T, value, out, allctr);
+        return utils.hashTreeRootBitlist(T, value, out, allctr);
     }
 
     const type_info = @typeInfo(T);
@@ -821,8 +598,8 @@ pub fn hashTreeRoot(comptime T: type, value: T, out: *[32]u8, allctr: Allocator)
         .int, .bool => {
             var list = ArrayList(u8).init(allctr);
             defer list.deinit();
-            const chunks = try pack(T, value, &list);
-            try merkleize(sha256, chunks, null, out);
+            const chunks = try utils.pack(T, value, &list);
+            try utils.merkleize(sha256, chunks, null, out);
         },
         .array => |a| {
             // Check if the child is a basic type. If so, return
@@ -833,14 +610,14 @@ pub fn hashTreeRoot(comptime T: type, value: T, out: *[32]u8, allctr: Allocator)
                 .int => {
                     var list = ArrayList(u8).init(allctr);
                     defer list.deinit();
-                    const chunks = try pack(T, value, &list);
-                    try merkleize(sha256, chunks, null, out);
+                    const chunks = try utils.pack(T, value, &list);
+                    try utils.merkleize(sha256, chunks, null, out);
                 },
                 .bool => {
                     var list = ArrayList(u8).init(allctr);
                     defer list.deinit();
                     const chunks = try packBits(value[0..], &list);
-                    try merkleize(sha256, chunks, chunkCount(T), out);
+                    try utils.merkleize(sha256, chunks, chunkCount(T), out);
                 },
                 .array => {
                     var chunks = ArrayList(chunk).init(allctr);
@@ -850,7 +627,7 @@ pub fn hashTreeRoot(comptime T: type, value: T, out: *[32]u8, allctr: Allocator)
                         try hashTreeRoot(@TypeOf(item), item, &tmp, allctr);
                         try chunks.append(tmp);
                     }
-                    try merkleize(sha256, chunks.items, null, out);
+                    try utils.merkleize(sha256, chunks.items, null, out);
                 },
                 else => return error.NotSupported,
             }
@@ -863,10 +640,10 @@ pub fn hashTreeRoot(comptime T: type, value: T, out: *[32]u8, allctr: Allocator)
                         .int => {
                             var list = ArrayList(u8).init(allctr);
                             defer list.deinit();
-                            const chunks = try pack(T, value, &list);
+                            const chunks = try utils.pack(T, value, &list);
                             var tmp: chunk = undefined;
-                            try merkleize(sha256, chunks, null, &tmp);
-                            mixInLength2(tmp, value.len, out);
+                            try utils.merkleize(sha256, chunks, null, &tmp);
+                            utils.mixInLength2(tmp, value.len, out);
                         },
                         // use bitlist
                         .bool => return error.UnSupportedPointerType,
@@ -879,8 +656,8 @@ pub fn hashTreeRoot(comptime T: type, value: T, out: *[32]u8, allctr: Allocator)
                                 try hashTreeRoot(@TypeOf(item), item, &tmp, allctr);
                                 try chunks.append(tmp);
                             }
-                            try merkleize(sha256, chunks.items, null, &tmp);
-                            mixInLength2(tmp, chunks.items.len, out);
+                            try utils.merkleize(sha256, chunks.items, null, &tmp);
+                            utils.mixInLength2(tmp, chunks.items.len, out);
                         },
                     }
                 },
@@ -895,7 +672,7 @@ pub fn hashTreeRoot(comptime T: type, value: T, out: *[32]u8, allctr: Allocator)
                 try hashTreeRoot(f.type, @field(value, f.name), &tmp, allctr);
                 try chunks.append(tmp);
             }
-            try merkleize(sha256, chunks.items, null, out);
+            try utils.merkleize(sha256, chunks.items, null, out);
         },
         // An optional is a union with `None` as first value.
         .optional => |opt| if (value != null) {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -1,4 +1,4 @@
-const libssz = @import("lib.zig");
+const libssz = @import("ssz.zig");
 const utils = libssz.utils;
 const serialize = libssz.serialize;
 const deserialize = libssz.deserialize;

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -978,6 +978,23 @@ test "List of composite types tree root" {
     try expect(!std.mem.eql(u8, &hash1, &hash3));
 }
 
+test "isFixedSizeObject correctly identifies List/Bitlist as variable-size" {
+    const ListType = utils.List(u64, 100);
+    const BitlistType = utils.Bitlist(100);
+    
+    // List and Bitlist should be identified as variable-size per SSZ spec
+    try expect(!try isFixedSizeObject(ListType));
+    try expect(!try isFixedSizeObject(BitlistType));
+    
+    // Struct containing List/Bitlist should also be variable-size
+    const StructWithList = struct {
+        id: u64,
+        votes: ListType,
+    };
+    
+    try expect(!try isFixedSizeObject(StructWithList));
+}
+
 test "Zeam-style List/Bitlist usage with tree root stability" {
     const MAX_VALIDATORS = 2048;
     const MAX_HISTORICAL_BLOCK_HASHES = 4096;

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -897,85 +897,85 @@ test "slice hashtree root simple type" {
 
 test "List tree root calculation" {
     const ListU64 = utils.List(u64, 1024);
-    
+
     const empty_list = try ListU64.init(0);
     var list_with_items = try ListU64.init(0);
     try list_with_items.append(42);
     try list_with_items.append(123);
     try list_with_items.append(456);
-    
+
     var empty_hash: [32]u8 = undefined;
     var filled_hash: [32]u8 = undefined;
-    
+
     try hashTreeRoot(ListU64, empty_list, &empty_hash, std.testing.allocator);
     try hashTreeRoot(ListU64, list_with_items, &filled_hash, std.testing.allocator);
-    
+
     try expect(!std.mem.eql(u8, &empty_hash, &filled_hash));
-    
+
     var same_content_list = try ListU64.init(0);
     try same_content_list.append(42);
     try same_content_list.append(123);
     try same_content_list.append(456);
-    
+
     var same_content_hash: [32]u8 = undefined;
     try hashTreeRoot(ListU64, same_content_list, &same_content_hash, std.testing.allocator);
-    
+
     try expect(std.mem.eql(u8, &filled_hash, &same_content_hash));
 }
 
 test "Bitlist tree root calculation" {
     const TestBitlist = utils.Bitlist(256);
-    
+
     const empty_bitlist = try TestBitlist.init(0);
     var filled_bitlist = try TestBitlist.init(0);
     try filled_bitlist.append(true);
     try filled_bitlist.append(false);
     try filled_bitlist.append(true);
     try filled_bitlist.append(true);
-    
+
     var empty_hash: [32]u8 = undefined;
     var filled_hash: [32]u8 = undefined;
-    
+
     try hashTreeRoot(TestBitlist, empty_bitlist, &empty_hash, std.testing.allocator);
     try hashTreeRoot(TestBitlist, filled_bitlist, &filled_hash, std.testing.allocator);
-    
+
     try expect(!std.mem.eql(u8, &empty_hash, &filled_hash));
-    
+
     var same_content_bitlist = try TestBitlist.init(0);
     try same_content_bitlist.append(true);
     try same_content_bitlist.append(false);
     try same_content_bitlist.append(true);
     try same_content_bitlist.append(true);
-    
+
     var same_content_hash: [32]u8 = undefined;
     try hashTreeRoot(TestBitlist, same_content_bitlist, &same_content_hash, std.testing.allocator);
-    
+
     try expect(std.mem.eql(u8, &filled_hash, &same_content_hash));
 }
 
 test "List of composite types tree root" {
     const ListOfPastry = utils.List(Pastry, 100);
-    
+
     var pastry_list = try ListOfPastry.init(0);
     try pastry_list.append(Pastry{ .name = "croissant", .weight = 20 });
     try pastry_list.append(Pastry{ .name = "muffin", .weight = 30 });
-    
+
     var hash1: [32]u8 = undefined;
     try hashTreeRoot(ListOfPastry, pastry_list, &hash1, std.testing.allocator);
-    
+
     var pastry_list2 = try ListOfPastry.init(0);
     try pastry_list2.append(Pastry{ .name = "croissant", .weight = 20 });
     try pastry_list2.append(Pastry{ .name = "muffin", .weight = 30 });
-    
+
     var hash2: [32]u8 = undefined;
     try hashTreeRoot(ListOfPastry, pastry_list2, &hash2, std.testing.allocator);
-    
+
     try expect(std.mem.eql(u8, &hash1, &hash2));
-    
+
     try pastry_list2.append(Pastry{ .name = "bagel", .weight = 25 });
     var hash3: [32]u8 = undefined;
     try hashTreeRoot(ListOfPastry, pastry_list2, &hash3, std.testing.allocator);
-    
+
     try expect(!std.mem.eql(u8, &hash1, &hash3));
 }
 
@@ -985,46 +985,46 @@ test "serializedSize correctly calculates List/Bitlist sizes" {
     var list = try ListType.init(0);
     try list.append(123);
     try list.append(456);
-    
+
     // Verify serializedSize matches actual serialization
     var serialized = ArrayList(u8).init(std.testing.allocator);
     defer serialized.deinit();
     try serialize(ListType, list, &serialized);
-    
+
     const calculated_size = try serializedSize(ListType, list);
     try expect(calculated_size == serialized.items.len);
-    
+
     // Test Bitlist size calculation
     const BitlistType = utils.Bitlist(256);
     var bitlist = try BitlistType.init(0);
     try bitlist.append(true);
     try bitlist.append(false);
     try bitlist.append(true);
-    
+
     var bitlist_serialized = ArrayList(u8).init(std.testing.allocator);
     defer bitlist_serialized.deinit();
     try serialize(BitlistType, bitlist, &bitlist_serialized);
-    
+
     const bitlist_calculated_size = try serializedSize(BitlistType, bitlist);
     try expect(bitlist_calculated_size == bitlist_serialized.items.len);
-    
+
     // Test struct containing List/Bitlist
     const StructWithContainers = struct {
         id: u64,
         votes: ListType,
         flags: BitlistType,
     };
-    
+
     const test_struct = StructWithContainers{
         .id = 42,
         .votes = list,
         .flags = bitlist,
     };
-    
+
     var struct_serialized = ArrayList(u8).init(std.testing.allocator);
     defer struct_serialized.deinit();
     try serialize(StructWithContainers, test_struct, &struct_serialized);
-    
+
     const struct_calculated_size = try serializedSize(StructWithContainers, test_struct);
     try expect(struct_calculated_size == struct_serialized.items.len);
 }
@@ -1032,31 +1032,31 @@ test "serializedSize correctly calculates List/Bitlist sizes" {
 test "isFixedSizeObject correctly identifies List/Bitlist as variable-size" {
     const ListType = utils.List(u64, 100);
     const BitlistType = utils.Bitlist(100);
-    
+
     // List and Bitlist should be identified as variable-size per SSZ spec
     try expect(!try isFixedSizeObject(ListType));
     try expect(!try isFixedSizeObject(BitlistType));
-    
+
     // Struct containing List/Bitlist should also be variable-size
     const StructWithList = struct {
         id: u64,
         votes: ListType,
     };
-    
+
     try expect(!try isFixedSizeObject(StructWithList));
 }
 
 test "Zeam-style List/Bitlist usage with tree root stability" {
     const MAX_VALIDATORS = 2048;
     const MAX_HISTORICAL_BLOCK_HASHES = 4096;
-    
+
     const Root = [32]u8;
-    
+
     const Mini3SFCheckpoint = struct {
         root: Root,
         slot: u64,
     };
-    
+
     const Mini3SFVote = struct {
         validator_id: u64,
         slot: u64,
@@ -1064,21 +1064,21 @@ test "Zeam-style List/Bitlist usage with tree root stability" {
         target: Mini3SFCheckpoint,
         source: Mini3SFCheckpoint,
     };
-    
+
     const Mini3SFVotes = utils.List(Mini3SFVote, MAX_VALIDATORS);
     const HistoricalBlockHashes = utils.List(Root, MAX_HISTORICAL_BLOCK_HASHES);
     const JustifiedSlots = utils.Bitlist(MAX_HISTORICAL_BLOCK_HASHES);
-    
+
     const BeamBlockBody = struct {
         votes: Mini3SFVotes,
     };
-    
+
     const BeamState = struct {
         slot: u64,
         historical_block_hashes: HistoricalBlockHashes,
         justified_slots: JustifiedSlots,
     };
-    
+
     var votes = try Mini3SFVotes.init(0);
     try votes.append(Mini3SFVote{
         .validator_id = 1,
@@ -1087,33 +1087,33 @@ test "Zeam-style List/Bitlist usage with tree root stability" {
         .target = Mini3SFCheckpoint{ .root = [_]u8{2} ** 32, .slot = 9 },
         .source = Mini3SFCheckpoint{ .root = [_]u8{3} ** 32, .slot = 8 },
     });
-    
+
     var hashes = try HistoricalBlockHashes.init(0);
     try hashes.append([_]u8{0xaa} ** 32);
     try hashes.append([_]u8{0xbb} ** 32);
-    
+
     var bitlist = try JustifiedSlots.init(0);
     try bitlist.append(true);
     try bitlist.append(false);
     try bitlist.append(true);
-    
+
     const body = BeamBlockBody{ .votes = votes };
     const state = BeamState{
         .slot = 42,
         .historical_block_hashes = hashes,
         .justified_slots = bitlist,
     };
-    
+
     var body_hash1: [32]u8 = undefined;
     var body_hash2: [32]u8 = undefined;
     var state_hash1: [32]u8 = undefined;
     var state_hash2: [32]u8 = undefined;
-    
+
     try hashTreeRoot(BeamBlockBody, body, &body_hash1, std.testing.allocator);
     try hashTreeRoot(BeamBlockBody, body, &body_hash2, std.testing.allocator);
     try hashTreeRoot(BeamState, state, &state_hash1, std.testing.allocator);
     try hashTreeRoot(BeamState, state, &state_hash2, std.testing.allocator);
-    
+
     try expect(std.mem.eql(u8, &body_hash1, &body_hash2));
     try expect(std.mem.eql(u8, &state_hash1, &state_hash2));
 }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -1,4 +1,4 @@
-const libssz = @import("ssz.zig");
+const libssz = @import("lib.zig");
 const utils = libssz.utils;
 const serialize = libssz.serialize;
 const deserialize = libssz.deserialize;
@@ -892,6 +892,162 @@ test "slice hashtree root simple type" {
     // computed from nodejs ssz lib for List[u8,33]
     const expected_hash_root = [_]u8{ 229, 104, 130, 10, 13, 251, 109, 221, 13, 70, 107, 87, 182, 228, 3, 211, 49, 235, 199, 224, 42, 133, 57, 250, 72, 21, 166, 87, 206, 112, 35, 203 };
     try expect(std.mem.eql(u8, &expected_hash_root, &hash_root));
+}
+
+test "List tree root calculation" {
+    const ListU64 = utils.List(u64, 1024);
+    
+    const empty_list = try ListU64.init(0);
+    var list_with_items = try ListU64.init(0);
+    try list_with_items.append(42);
+    try list_with_items.append(123);
+    try list_with_items.append(456);
+    
+    var empty_hash: [32]u8 = undefined;
+    var filled_hash: [32]u8 = undefined;
+    
+    try hashTreeRoot(ListU64, empty_list, &empty_hash, std.testing.allocator);
+    try hashTreeRoot(ListU64, list_with_items, &filled_hash, std.testing.allocator);
+    
+    try expect(!std.mem.eql(u8, &empty_hash, &filled_hash));
+    
+    var same_content_list = try ListU64.init(0);
+    try same_content_list.append(42);
+    try same_content_list.append(123);
+    try same_content_list.append(456);
+    
+    var same_content_hash: [32]u8 = undefined;
+    try hashTreeRoot(ListU64, same_content_list, &same_content_hash, std.testing.allocator);
+    
+    try expect(std.mem.eql(u8, &filled_hash, &same_content_hash));
+}
+
+test "Bitlist tree root calculation" {
+    const TestBitlist = utils.Bitlist(256);
+    
+    const empty_bitlist = try TestBitlist.init(0);
+    var filled_bitlist = try TestBitlist.init(0);
+    try filled_bitlist.append(true);
+    try filled_bitlist.append(false);
+    try filled_bitlist.append(true);
+    try filled_bitlist.append(true);
+    
+    var empty_hash: [32]u8 = undefined;
+    var filled_hash: [32]u8 = undefined;
+    
+    try hashTreeRoot(TestBitlist, empty_bitlist, &empty_hash, std.testing.allocator);
+    try hashTreeRoot(TestBitlist, filled_bitlist, &filled_hash, std.testing.allocator);
+    
+    try expect(!std.mem.eql(u8, &empty_hash, &filled_hash));
+    
+    var same_content_bitlist = try TestBitlist.init(0);
+    try same_content_bitlist.append(true);
+    try same_content_bitlist.append(false);
+    try same_content_bitlist.append(true);
+    try same_content_bitlist.append(true);
+    
+    var same_content_hash: [32]u8 = undefined;
+    try hashTreeRoot(TestBitlist, same_content_bitlist, &same_content_hash, std.testing.allocator);
+    
+    try expect(std.mem.eql(u8, &filled_hash, &same_content_hash));
+}
+
+test "List of composite types tree root" {
+    const ListOfPastry = utils.List(Pastry, 100);
+    
+    var pastry_list = try ListOfPastry.init(0);
+    try pastry_list.append(Pastry{ .name = "croissant", .weight = 20 });
+    try pastry_list.append(Pastry{ .name = "muffin", .weight = 30 });
+    
+    var hash1: [32]u8 = undefined;
+    try hashTreeRoot(ListOfPastry, pastry_list, &hash1, std.testing.allocator);
+    
+    var pastry_list2 = try ListOfPastry.init(0);
+    try pastry_list2.append(Pastry{ .name = "croissant", .weight = 20 });
+    try pastry_list2.append(Pastry{ .name = "muffin", .weight = 30 });
+    
+    var hash2: [32]u8 = undefined;
+    try hashTreeRoot(ListOfPastry, pastry_list2, &hash2, std.testing.allocator);
+    
+    try expect(std.mem.eql(u8, &hash1, &hash2));
+    
+    try pastry_list2.append(Pastry{ .name = "bagel", .weight = 25 });
+    var hash3: [32]u8 = undefined;
+    try hashTreeRoot(ListOfPastry, pastry_list2, &hash3, std.testing.allocator);
+    
+    try expect(!std.mem.eql(u8, &hash1, &hash3));
+}
+
+test "Zeam-style List/Bitlist usage with tree root stability" {
+    const MAX_VALIDATORS = 2048;
+    const MAX_HISTORICAL_BLOCK_HASHES = 4096;
+    
+    const Root = [32]u8;
+    
+    const Mini3SFCheckpoint = struct {
+        root: Root,
+        slot: u64,
+    };
+    
+    const Mini3SFVote = struct {
+        validator_id: u64,
+        slot: u64,
+        head: Mini3SFCheckpoint,
+        target: Mini3SFCheckpoint,
+        source: Mini3SFCheckpoint,
+    };
+    
+    const Mini3SFVotes = utils.List(Mini3SFVote, MAX_VALIDATORS);
+    const HistoricalBlockHashes = utils.List(Root, MAX_HISTORICAL_BLOCK_HASHES);
+    const JustifiedSlots = utils.Bitlist(MAX_HISTORICAL_BLOCK_HASHES);
+    
+    const BeamBlockBody = struct {
+        votes: Mini3SFVotes,
+    };
+    
+    const BeamState = struct {
+        slot: u64,
+        historical_block_hashes: HistoricalBlockHashes,
+        justified_slots: JustifiedSlots,
+    };
+    
+    var votes = try Mini3SFVotes.init(0);
+    try votes.append(Mini3SFVote{
+        .validator_id = 1,
+        .slot = 10,
+        .head = Mini3SFCheckpoint{ .root = [_]u8{1} ** 32, .slot = 10 },
+        .target = Mini3SFCheckpoint{ .root = [_]u8{2} ** 32, .slot = 9 },
+        .source = Mini3SFCheckpoint{ .root = [_]u8{3} ** 32, .slot = 8 },
+    });
+    
+    var hashes = try HistoricalBlockHashes.init(0);
+    try hashes.append([_]u8{0xaa} ** 32);
+    try hashes.append([_]u8{0xbb} ** 32);
+    
+    var bitlist = try JustifiedSlots.init(0);
+    try bitlist.append(true);
+    try bitlist.append(false);
+    try bitlist.append(true);
+    
+    const body = BeamBlockBody{ .votes = votes };
+    const state = BeamState{
+        .slot = 42,
+        .historical_block_hashes = hashes,
+        .justified_slots = bitlist,
+    };
+    
+    var body_hash1: [32]u8 = undefined;
+    var body_hash2: [32]u8 = undefined;
+    var state_hash1: [32]u8 = undefined;
+    var state_hash2: [32]u8 = undefined;
+    
+    try hashTreeRoot(BeamBlockBody, body, &body_hash1, std.testing.allocator);
+    try hashTreeRoot(BeamBlockBody, body, &body_hash2, std.testing.allocator);
+    try hashTreeRoot(BeamState, state, &state_hash1, std.testing.allocator);
+    try hashTreeRoot(BeamState, state, &state_hash2, std.testing.allocator);
+    
+    try expect(std.mem.eql(u8, &body_hash1, &body_hash2));
+    try expect(std.mem.eql(u8, &state_hash1, &state_hash2));
 }
 
 test "zeam stf input" {

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -4,6 +4,14 @@ const serialize = lib.serialize;
 const deserialize = lib.deserialize;
 const isFixedSizeObject = lib.isFixedSizeObject;
 const ArrayList = std.ArrayList;
+const Allocator = std.mem.Allocator;
+const sha256 = std.crypto.hash.sha2.Sha256;
+const hashes_of_zero = @import("./zeros.zig").hashes_of_zero;
+
+// SSZ specification constants
+const BYTES_PER_CHUNK = lib.BYTES_PER_CHUNK;
+const chunk = lib.chunk;
+const zero_chunk = lib.zero_chunk;
 
 /// Returns true if the type is a utils.List type
 pub fn isListType(comptime T: type) bool {
@@ -222,4 +230,230 @@ pub fn Bitlist(comptime N: usize) type {
             return (self.length + 8) / 8;
         }
     };
+}
+pub fn mixInLength2(root: [32]u8, length: usize, out: *[32]u8) void {
+    var hasher = sha256.init(sha256.Options{});
+    hasher.update(root[0..]);
+
+    var tmp = [_]u8{0} ** 32;
+    std.mem.writeInt(@TypeOf(length), tmp[0..@sizeOf(@TypeOf(length))], length, std.builtin.Endian.little);
+    hasher.update(tmp[0..]);
+    hasher.final(out[0..]);
+}
+
+pub fn pack(comptime T: type, values: T, l: *ArrayList(u8)) ![]chunk {
+    try serialize(T, values, l);
+    const padding_size = (BYTES_PER_CHUNK - l.items.len % BYTES_PER_CHUNK) % BYTES_PER_CHUNK;
+    _ = try l.writer().write(zero_chunk[0..padding_size]);
+    return std.mem.bytesAsSlice(chunk, l.items);
+}
+
+// merkleize recursively calculates the root hash of a Merkle tree.
+pub fn merkleize(hasher: type, chunks: []chunk, limit: ?usize, out: *[32]u8) anyerror!void {
+    // Calculate the number of chunks to be padded, check the limit
+    if (limit != null and chunks.len > limit.?) {
+        return error.ChunkSizeExceedsLimit;
+    }
+    const power = limit orelse chunks.len;
+    const size = if (power > 0) try std.math.ceilPowerOfTwo(usize, power) else 0;
+
+    // Perform the merkelization
+    switch (size) {
+        0 => std.mem.copyForwards(u8, out.*[0..], zero_chunk[0..]),
+        1 => std.mem.copyForwards(u8, out.*[0..], chunks[0][0..]),
+        else => {
+            // Merkleize the left side. If the number of chunks
+            // isn't enough to fill the entire width, complete
+            // with zeroes.
+            var digest = hasher.init(hasher.Options{});
+            var buf: [32]u8 = undefined;
+            const split = if (size / 2 < chunks.len) size / 2 else chunks.len;
+            try merkleize(hasher, chunks[0..split], size / 2, &buf);
+            digest.update(buf[0..]);
+
+            // Merkleize the right side. If the number of chunks only
+            // covers the first half, directly input the hashed zero-
+            // filled subtrie.
+            if (size / 2 < chunks.len) {
+                try merkleize(hasher, chunks[size / 2 ..], size / 2, &buf);
+                digest.update(buf[0..]);
+            } else digest.update(hashes_of_zero[size / 2 - 1][0..]);
+            digest.final(out);
+        },
+    }
+}
+
+/// Specialized hash tree root function for List types
+/// Implements the required mix_in_length operation for variable-length containers
+pub fn hashTreeRootList(comptime T: type, value: T, out: *[32]u8, allctr: Allocator) !void {
+    const slice = value.constSlice();
+
+    if (slice.len == 0) {
+        const tmp: chunk = zero_chunk;
+        mixInLength2(tmp, 0, out);
+        return;
+    }
+
+    const Item = @TypeOf(slice[0]);
+    switch (@typeInfo(Item)) {
+        .int => {
+            var list = ArrayList(u8).init(allctr);
+            defer list.deinit();
+            const chunks = try pack([]const Item, slice, &list);
+            var tmp: chunk = undefined;
+            try merkleize(sha256, chunks, null, &tmp);
+            mixInLength2(tmp, slice.len, out);
+        },
+        else => {
+            var chunks = ArrayList(chunk).init(allctr);
+            defer chunks.deinit();
+            var tmp: chunk = undefined;
+            for (slice) |item| {
+                try lib.hashTreeRoot(Item, item, &tmp, allctr);
+                try chunks.append(tmp);
+            }
+            try merkleize(sha256, chunks.items, null, &tmp);
+            mixInLength2(tmp, slice.len, out);
+        },
+    }
+}
+
+/// Specialized hash tree root function for Bitlist types
+/// Implements the required mix_in_length operation for variable-length containers
+pub fn hashTreeRootBitlist(comptime T: type, value: T, out: *[32]u8, allctr: Allocator) !void {
+    const bit_length = value.length;
+    if (bit_length == 0) {
+        const tmp: chunk = zero_chunk;
+        mixInLength2(tmp, 0, out);
+        return;
+    }
+
+    var list = ArrayList(u8).init(allctr);
+    defer list.deinit();
+
+    const byte_slice = value.inner.constSlice();
+    const full_bytes = bit_length / 8;
+    const remaining_bits = bit_length % 8;
+
+    if (full_bytes > 0) {
+        try list.appendSlice(byte_slice[0..full_bytes]);
+    }
+
+    if (remaining_bits > 0) {
+        const last_byte = byte_slice[full_bytes];
+        const mask = (@as(u8, 1) << @truncate(remaining_bits)) - 1;
+        try list.append(last_byte & mask);
+    }
+
+    const padding_size = (BYTES_PER_CHUNK - list.items.len % BYTES_PER_CHUNK) % BYTES_PER_CHUNK;
+    _ = try list.writer().write(zero_chunk[0..padding_size]);
+
+    const chunks = std.mem.bytesAsSlice(chunk, list.items);
+    var tmp: chunk = undefined;
+    try merkleize(sha256, chunks, null, &tmp);
+    mixInLength2(tmp, bit_length, out);
+}
+
+test "pack u32" {
+    var expected: [32]u8 = undefined;
+    var list = ArrayList(u8).init(std.testing.allocator);
+    defer list.deinit();
+    const out = try pack(u32, 0xdeadbeef, &list);
+
+    _ = try std.fmt.hexToBytes(expected[0..], "efbeadde00000000000000000000000000000000000000000000000000000000");
+
+    try std.testing.expect(std.mem.eql(u8, out[0][0..], expected[0..]));
+}
+
+test "pack bool" {
+    var expected: [32]u8 = undefined;
+    var list = ArrayList(u8).init(std.testing.allocator);
+    defer list.deinit();
+    const out = try pack(bool, true, &list);
+
+    _ = try std.fmt.hexToBytes(expected[0..], "0100000000000000000000000000000000000000000000000000000000000000");
+
+    try std.testing.expect(std.mem.eql(u8, out[0][0..], expected[0..]));
+}
+
+test "pack string" {
+    var expected: [128]u8 = undefined;
+    var list = ArrayList(u8).init(std.testing.allocator);
+    defer list.deinit();
+    const out = try pack([]const u8, "a" ** 100, &list);
+
+    _ = try std.fmt.hexToBytes(expected[0..], "6161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616100000000000000000000000000000000000000000000000000000000");
+
+    try std.testing.expect(expected.len == out.len * out[0].len);
+    try std.testing.expect(std.mem.eql(u8, out[0][0..], expected[0..32]));
+    try std.testing.expect(std.mem.eql(u8, out[1][0..], expected[32..64]));
+    try std.testing.expect(std.mem.eql(u8, out[2][0..], expected[64..96]));
+    try std.testing.expect(std.mem.eql(u8, out[3][0..], expected[96..]));
+}
+
+test "merkleize an empty slice" {
+    var list = ArrayList(u8).init(std.testing.allocator);
+    defer list.deinit();
+    const chunks = &[0][32]u8{};
+    var out: [32]u8 = undefined;
+    try merkleize(sha256, chunks, null, &out);
+    try std.testing.expect(std.mem.eql(u8, out[0..], zero_chunk[0..]));
+}
+
+test "merkleize a string" {
+    var list = ArrayList(u8).init(std.testing.allocator);
+    defer list.deinit();
+    const chunks = try pack([]const u8, "a" ** 100, &list);
+    var out: [32]u8 = undefined;
+    try merkleize(sha256, chunks, null, &out);
+    // Build the expected tree
+    const leaf1 = [_]u8{0x61} ** 32; // "0xaaaaa....aa" 32 times
+    var leaf2: [32]u8 = [_]u8{0x61} ** 4 ++ [_]u8{0} ** 28;
+    var root: [32]u8 = undefined;
+    var internal_left: [32]u8 = undefined;
+    var internal_right: [32]u8 = undefined;
+    var hasher = sha256.init(sha256.Options{});
+    hasher.update(leaf1[0..]);
+    hasher.update(leaf1[0..]);
+    hasher.final(&internal_left);
+    hasher = sha256.init(sha256.Options{});
+    hasher.update(leaf1[0..]);
+    hasher.update(leaf2[0..]);
+    hasher.final(&internal_right);
+    hasher = sha256.init(sha256.Options{});
+    hasher.update(internal_left[0..]);
+    hasher.update(internal_right[0..]);
+    hasher.final(&root);
+
+    try std.testing.expect(std.mem.eql(u8, out[0..], root[0..]));
+}
+
+test "merkleize a boolean" {
+    var list = ArrayList(u8).init(std.testing.allocator);
+    defer list.deinit();
+
+    var chunks = try pack(bool, false, &list);
+    var expected = [_]u8{0} ** BYTES_PER_CHUNK;
+    var out: [BYTES_PER_CHUNK]u8 = undefined;
+    try merkleize(sha256, chunks, null, &out);
+
+    try std.testing.expect(std.mem.eql(u8, out[0..], expected[0..]));
+
+    var list2 = ArrayList(u8).init(std.testing.allocator);
+    defer list2.deinit();
+
+    chunks = try pack(bool, true, &list2);
+    expected[0] = 1;
+    try merkleize(sha256, chunks, null, &out);
+    try std.testing.expect(std.mem.eql(u8, out[0..], expected[0..]));
+}
+
+test "merkleize a bytes16 vector with one element" {
+    var list = ArrayList(u8).init(std.testing.allocator);
+    defer list.deinit();
+    _ = try pack([16]u8, [_]u8{0xaa} ** 16, &list);
+    // var expected: [32]u8 = [_]u8{0xaa} ** 16 ++ [_]u8{0x00} ** 16;
+    // var out: [32]u8 = undefined;
+    // try merkleize(sha256, chunks, null, &out);
+    // try std.testing.expect(std.mem.eql(u8, out[0..], expected[0..]));
 }

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -120,6 +120,11 @@ pub fn List(comptime T: type, comptime N: usize) type {
         pub fn len(self: *Self) usize {
             return self.inner.len;
         }
+
+        pub fn serializedSize(self: *const Self) !usize {
+            const inner_slice = self.inner.constSlice();
+            return lib.serializedSize(@TypeOf(inner_slice), inner_slice);
+        }
     };
 }
 
@@ -209,6 +214,12 @@ pub fn Bitlist(comptime N: usize) type {
 
         pub fn eql(self: *const Self, other: *Self) bool {
             return (self.length == other.length) and std.mem.eql(u8, self.inner.constSlice()[0..self.inner.len], other.inner.constSlice()[0..other.inner.len]);
+        }
+
+        pub fn serializedSize(self: *const Self) usize {
+            if (self.length == 0) return 0;
+            // Size is number of bytes needed plus one bit for the sentinel
+            return (self.length + 8) / 8;
         }
     };
 }

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -64,6 +64,10 @@ pub fn List(comptime T: type, comptime N: usize) type {
             return self.inner.slice();
         }
 
+        pub fn constSlice(self: *const Self) []const T {
+            return self.inner.constSlice();
+        }
+
         pub fn fromSlice(m: []const T) error{Overflow}!Self {
             return .{ .inner = try Inner.fromSlice(m) };
         }

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -17,7 +17,7 @@ const zero_chunk: chunk = [_]u8{0} ** BYTES_PER_CHUNK;
 pub fn isListType(comptime T: type) bool {
     @setEvalBranchQuota(4000);
     if (@typeInfo(T) != .@"struct") return false;
-    
+
     // Check if this is a List type by examining the type name
     return std.mem.indexOf(u8, @typeName(T), "utils.List(") != null;
 }
@@ -26,7 +26,7 @@ pub fn isListType(comptime T: type) bool {
 pub fn isBitlistType(comptime T: type) bool {
     @setEvalBranchQuota(4000);
     if (@typeInfo(T) != .@"struct") return false;
-    
+
     // Check if this is a Bitlist type by examining the type name
     return std.mem.indexOf(u8, @typeName(T), "utils.Bitlist(") != null;
 }

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -11,6 +11,7 @@ pub fn List(comptime T: type, comptime N: usize) type {
         const Self = @This();
         const Item = T;
         const Inner = std.BoundedArray(T, N);
+        const ssz_type_kind = .list;
 
         inner: Inner,
 
@@ -91,6 +92,7 @@ pub fn Bitlist(comptime N: usize) type {
     return struct {
         const Self = @This();
         const Inner = std.BoundedArray(u8, (N + 7) / 8);
+        const ssz_type_kind = .bitlist;
 
         inner: Inner,
         length: usize,

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -9,9 +9,9 @@ const sha256 = std.crypto.hash.sha2.Sha256;
 const hashes_of_zero = @import("./zeros.zig").hashes_of_zero;
 
 // SSZ specification constants
-const BYTES_PER_CHUNK = lib.BYTES_PER_CHUNK;
-const chunk = lib.chunk;
-const zero_chunk = lib.zero_chunk;
+const BYTES_PER_CHUNK = 32;
+const chunk = [BYTES_PER_CHUNK]u8;
+const zero_chunk: chunk = [_]u8{0} ** BYTES_PER_CHUNK;
 
 /// Returns true if the type is a utils.List type
 pub fn isListType(comptime T: type) bool {
@@ -231,57 +231,6 @@ pub fn Bitlist(comptime N: usize) type {
         }
     };
 }
-pub fn mixInLength2(root: [32]u8, length: usize, out: *[32]u8) void {
-    var hasher = sha256.init(sha256.Options{});
-    hasher.update(root[0..]);
-
-    var tmp = [_]u8{0} ** 32;
-    std.mem.writeInt(@TypeOf(length), tmp[0..@sizeOf(@TypeOf(length))], length, std.builtin.Endian.little);
-    hasher.update(tmp[0..]);
-    hasher.final(out[0..]);
-}
-
-pub fn pack(comptime T: type, values: T, l: *ArrayList(u8)) ![]chunk {
-    try serialize(T, values, l);
-    const padding_size = (BYTES_PER_CHUNK - l.items.len % BYTES_PER_CHUNK) % BYTES_PER_CHUNK;
-    _ = try l.writer().write(zero_chunk[0..padding_size]);
-    return std.mem.bytesAsSlice(chunk, l.items);
-}
-
-// merkleize recursively calculates the root hash of a Merkle tree.
-pub fn merkleize(hasher: type, chunks: []chunk, limit: ?usize, out: *[32]u8) anyerror!void {
-    // Calculate the number of chunks to be padded, check the limit
-    if (limit != null and chunks.len > limit.?) {
-        return error.ChunkSizeExceedsLimit;
-    }
-    const power = limit orelse chunks.len;
-    const size = if (power > 0) try std.math.ceilPowerOfTwo(usize, power) else 0;
-
-    // Perform the merkelization
-    switch (size) {
-        0 => std.mem.copyForwards(u8, out.*[0..], zero_chunk[0..]),
-        1 => std.mem.copyForwards(u8, out.*[0..], chunks[0][0..]),
-        else => {
-            // Merkleize the left side. If the number of chunks
-            // isn't enough to fill the entire width, complete
-            // with zeroes.
-            var digest = hasher.init(hasher.Options{});
-            var buf: [32]u8 = undefined;
-            const split = if (size / 2 < chunks.len) size / 2 else chunks.len;
-            try merkleize(hasher, chunks[0..split], size / 2, &buf);
-            digest.update(buf[0..]);
-
-            // Merkleize the right side. If the number of chunks only
-            // covers the first half, directly input the hashed zero-
-            // filled subtrie.
-            if (size / 2 < chunks.len) {
-                try merkleize(hasher, chunks[size / 2 ..], size / 2, &buf);
-                digest.update(buf[0..]);
-            } else digest.update(hashes_of_zero[size / 2 - 1][0..]);
-            digest.final(out);
-        },
-    }
-}
 
 /// Specialized hash tree root function for List types
 /// Implements the required mix_in_length operation for variable-length containers
@@ -290,7 +239,7 @@ pub fn hashTreeRootList(comptime T: type, value: T, out: *[32]u8, allctr: Alloca
 
     if (slice.len == 0) {
         const tmp: chunk = zero_chunk;
-        mixInLength2(tmp, 0, out);
+        lib.mixInLength2(tmp, 0, out);
         return;
     }
 
@@ -299,10 +248,10 @@ pub fn hashTreeRootList(comptime T: type, value: T, out: *[32]u8, allctr: Alloca
         .int => {
             var list = ArrayList(u8).init(allctr);
             defer list.deinit();
-            const chunks = try pack([]const Item, slice, &list);
+            const chunks = try lib.pack([]const Item, slice, &list);
             var tmp: chunk = undefined;
-            try merkleize(sha256, chunks, null, &tmp);
-            mixInLength2(tmp, slice.len, out);
+            try lib.merkleize(sha256, chunks, null, &tmp);
+            lib.mixInLength2(tmp, slice.len, out);
         },
         else => {
             var chunks = ArrayList(chunk).init(allctr);
@@ -312,8 +261,8 @@ pub fn hashTreeRootList(comptime T: type, value: T, out: *[32]u8, allctr: Alloca
                 try lib.hashTreeRoot(Item, item, &tmp, allctr);
                 try chunks.append(tmp);
             }
-            try merkleize(sha256, chunks.items, null, &tmp);
-            mixInLength2(tmp, slice.len, out);
+            try lib.merkleize(sha256, chunks.items, null, &tmp);
+            lib.mixInLength2(tmp, slice.len, out);
         },
     }
 }
@@ -324,7 +273,7 @@ pub fn hashTreeRootBitlist(comptime T: type, value: T, out: *[32]u8, allctr: All
     const bit_length = value.length;
     if (bit_length == 0) {
         const tmp: chunk = zero_chunk;
-        mixInLength2(tmp, 0, out);
+        lib.mixInLength2(tmp, 0, out);
         return;
     }
 
@@ -350,110 +299,6 @@ pub fn hashTreeRootBitlist(comptime T: type, value: T, out: *[32]u8, allctr: All
 
     const chunks = std.mem.bytesAsSlice(chunk, list.items);
     var tmp: chunk = undefined;
-    try merkleize(sha256, chunks, null, &tmp);
-    mixInLength2(tmp, bit_length, out);
-}
-
-test "pack u32" {
-    var expected: [32]u8 = undefined;
-    var list = ArrayList(u8).init(std.testing.allocator);
-    defer list.deinit();
-    const out = try pack(u32, 0xdeadbeef, &list);
-
-    _ = try std.fmt.hexToBytes(expected[0..], "efbeadde00000000000000000000000000000000000000000000000000000000");
-
-    try std.testing.expect(std.mem.eql(u8, out[0][0..], expected[0..]));
-}
-
-test "pack bool" {
-    var expected: [32]u8 = undefined;
-    var list = ArrayList(u8).init(std.testing.allocator);
-    defer list.deinit();
-    const out = try pack(bool, true, &list);
-
-    _ = try std.fmt.hexToBytes(expected[0..], "0100000000000000000000000000000000000000000000000000000000000000");
-
-    try std.testing.expect(std.mem.eql(u8, out[0][0..], expected[0..]));
-}
-
-test "pack string" {
-    var expected: [128]u8 = undefined;
-    var list = ArrayList(u8).init(std.testing.allocator);
-    defer list.deinit();
-    const out = try pack([]const u8, "a" ** 100, &list);
-
-    _ = try std.fmt.hexToBytes(expected[0..], "6161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616100000000000000000000000000000000000000000000000000000000");
-
-    try std.testing.expect(expected.len == out.len * out[0].len);
-    try std.testing.expect(std.mem.eql(u8, out[0][0..], expected[0..32]));
-    try std.testing.expect(std.mem.eql(u8, out[1][0..], expected[32..64]));
-    try std.testing.expect(std.mem.eql(u8, out[2][0..], expected[64..96]));
-    try std.testing.expect(std.mem.eql(u8, out[3][0..], expected[96..]));
-}
-
-test "merkleize an empty slice" {
-    var list = ArrayList(u8).init(std.testing.allocator);
-    defer list.deinit();
-    const chunks = &[0][32]u8{};
-    var out: [32]u8 = undefined;
-    try merkleize(sha256, chunks, null, &out);
-    try std.testing.expect(std.mem.eql(u8, out[0..], zero_chunk[0..]));
-}
-
-test "merkleize a string" {
-    var list = ArrayList(u8).init(std.testing.allocator);
-    defer list.deinit();
-    const chunks = try pack([]const u8, "a" ** 100, &list);
-    var out: [32]u8 = undefined;
-    try merkleize(sha256, chunks, null, &out);
-    // Build the expected tree
-    const leaf1 = [_]u8{0x61} ** 32; // "0xaaaaa....aa" 32 times
-    var leaf2: [32]u8 = [_]u8{0x61} ** 4 ++ [_]u8{0} ** 28;
-    var root: [32]u8 = undefined;
-    var internal_left: [32]u8 = undefined;
-    var internal_right: [32]u8 = undefined;
-    var hasher = sha256.init(sha256.Options{});
-    hasher.update(leaf1[0..]);
-    hasher.update(leaf1[0..]);
-    hasher.final(&internal_left);
-    hasher = sha256.init(sha256.Options{});
-    hasher.update(leaf1[0..]);
-    hasher.update(leaf2[0..]);
-    hasher.final(&internal_right);
-    hasher = sha256.init(sha256.Options{});
-    hasher.update(internal_left[0..]);
-    hasher.update(internal_right[0..]);
-    hasher.final(&root);
-
-    try std.testing.expect(std.mem.eql(u8, out[0..], root[0..]));
-}
-
-test "merkleize a boolean" {
-    var list = ArrayList(u8).init(std.testing.allocator);
-    defer list.deinit();
-
-    var chunks = try pack(bool, false, &list);
-    var expected = [_]u8{0} ** BYTES_PER_CHUNK;
-    var out: [BYTES_PER_CHUNK]u8 = undefined;
-    try merkleize(sha256, chunks, null, &out);
-
-    try std.testing.expect(std.mem.eql(u8, out[0..], expected[0..]));
-
-    var list2 = ArrayList(u8).init(std.testing.allocator);
-    defer list2.deinit();
-
-    chunks = try pack(bool, true, &list2);
-    expected[0] = 1;
-    try merkleize(sha256, chunks, null, &out);
-    try std.testing.expect(std.mem.eql(u8, out[0..], expected[0..]));
-}
-
-test "merkleize a bytes16 vector with one element" {
-    var list = ArrayList(u8).init(std.testing.allocator);
-    defer list.deinit();
-    _ = try pack([16]u8, [_]u8{0xaa} ** 16, &list);
-    // var expected: [32]u8 = [_]u8{0xaa} ** 16 ++ [_]u8{0x00} ** 16;
-    // var out: [32]u8 = undefined;
-    // try merkleize(sha256, chunks, null, &out);
-    // try std.testing.expect(std.mem.eql(u8, out[0..], expected[0..]));
+    try lib.merkleize(sha256, chunks, null, &tmp);
+    lib.mixInLength2(tmp, bit_length, out);
 }

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -294,7 +294,7 @@ pub fn hashTreeRootList(comptime T: type, value: T, out: *[32]u8, allctr: Alloca
         return;
     }
 
-    const Item = @TypeOf(slice[0]);
+    const Item = T.Item;
     switch (@typeInfo(Item)) {
         .int => {
             var list = ArrayList(u8).init(allctr);

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -227,7 +227,7 @@ pub fn Bitlist(comptime N: usize) type {
         pub fn serializedSize(self: *const Self) usize {
             if (self.length == 0) return 0;
             // Size is number of bytes needed plus one bit for the sentinel
-            return (self.length + 8) / 8;
+            return (self.length + 7) / 8;
         }
     };
 }

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1,5 +1,8 @@
 const std = @import("std");
 const lib = @import("./lib.zig");
+
+// Zig compiler configuration
+const EVAL_BRANCH_QUOTA = 4000;
 const serialize = lib.serialize;
 const deserialize = lib.deserialize;
 const isFixedSizeObject = lib.isFixedSizeObject;
@@ -15,7 +18,7 @@ const zero_chunk: chunk = [_]u8{0} ** BYTES_PER_CHUNK;
 
 /// Returns true if the type is a utils.List type
 pub fn isListType(comptime T: type) bool {
-    @setEvalBranchQuota(4000);
+    @setEvalBranchQuota(EVAL_BRANCH_QUOTA);
     if (@typeInfo(T) != .@"struct") return false;
 
     // Check if this is a List type by examining the type name
@@ -24,7 +27,7 @@ pub fn isListType(comptime T: type) bool {
 
 /// Returns true if the type is a utils.Bitlist type
 pub fn isBitlistType(comptime T: type) bool {
-    @setEvalBranchQuota(4000);
+    @setEvalBranchQuota(EVAL_BRANCH_QUOTA);
     if (@typeInfo(T) != .@"struct") return false;
 
     // Check if this is a Bitlist type by examining the type name


### PR DESCRIPTION
## Description
Adds proper SSZ support for List and Bitlist variable-length containers by implementing type
  detection and specialized tree root calculation with length mix-in.
###  Changes:

  - Added isListType() and isBitlistType() detection functions with explicit ssz_type_kind markers
  - Implemented hashTreeRootList() and hashTreeRootBitlist() with proper length mix-in per SSZ spec
  - Added comprehensive tests covering serialization round-trips and tree root stability
 
###  Impact:

  - Enables proper SSZ compliance for variable-length containers
  - Fixes tree root stability issues with List/Bitlist types
  - Allows downstream projects (like Zeam) to use correct SSZ types instead of fallback slices

  Closes issues with SSZ List/Bitlist serialization and Merkle tree root calculation.