### PR TITLE
fix: hashTreeRoot generation from pointer

### DIFF
--- a/src/lib.zig
+++ b/src/lib.zig
@@ -799,7 +799,7 @@ pub fn hashTreeRoot(comptime T: type, value: T, out: *[32]u8, allctr: Allocator)
         },
         .pointer => |ptr| {
             switch (ptr.size) {
-                .one => hashTreeRoot(ptr.child, value.*, out, allctr),
+                .one => try hashTreeRoot(ptr.child, value.*, out, allctr),
                 .slice => {
                     switch (@typeInfo(ptr.child)) {
                         .int => {


### PR DESCRIPTION
Root generation fails with the following error when called on a pointer type
```
src/lib.zig:801:13: error: error union is ignored
            switch (ptr.size) {
            ^~~~~~
```