### PR TITLE
Implement bitlist-style SSZ encoding for []bool slices (#42)

### DIFF
--- a/src/tests.zig
+++ b/src/tests.zig
@@ -1595,7 +1595,7 @@ test "validateBitlist - comprehensive validation" {
     // Test empty bitlist
     {
         const empty_buf = [_]u8{};
-        try utils.Bitlist(10).validateBitlist(&empty_buf);
+        try std.testing.expectError(error.InvalidBitlistEncoding, utils.Bitlist(10).validateBitlist(&empty_buf));
     }
 
     // Test bitlist with trailing zero byte

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -235,33 +235,35 @@ pub fn Bitlist(comptime N: usize) type {
             // Comprehensive validation (handles empty, trailing zero, size limits)
             try Self.validateBitlist(serialized);
 
-            // If validation passed but buffer is empty, we're done
-            if (serialized.len == 0) {
-                return;
-            }
-
             // FastSSZ-style capacity optimization: pre-allocate based on input size
             const byte_capacity = serialized.len;
             if (byte_capacity > 0) {
                 try out.inner.ensureTotalCapacity(byte_capacity);
             }
 
-            // Parse the bit structure (validation already confirmed it's valid)
-            const byte_len = serialized.len - 1;
-            var last_byte = serialized[byte_len];
-            var bit_len: usize = 8;
-            while (last_byte & @shlExact(@as(usize, 1), @truncate(bit_len)) == 0) : (bit_len -= 1) {}
+            // Find sentinel bit position using @clz (count leading zeros)
+            const last_byte = serialized[serialized.len - 1];
+            const msb_pos = @as(usize, 8) - @clz(last_byte);
+            const bit_length = 8 * (serialized.len - 1) + (msb_pos - 1);
 
-            // insert all full bytes
-            try out.*.inner.insertSlice(0, serialized[0..byte_len]);
-            out.*.length = 8 * byte_len;
+            // Calculate how many full bytes we need (excluding sentinel)
+            const full_bytes = bit_length / 8;
+            const remaining_bits = bit_length % 8;
 
-            // insert last bits
-            last_byte = serialized[byte_len];
-            for (0..bit_len) |_| {
-                try out.*.append(last_byte & 1 == 1);
-                last_byte >>= 1;
+            // Copy all full bytes
+            if (full_bytes > 0) {
+                try out.*.inner.appendSlice(serialized[0..full_bytes]);
             }
+
+            // Handle remaining bits in the last byte (if any)
+            if (remaining_bits > 0) {
+                // The last byte contains both data bits and the sentinel bit
+                // We need to mask out the sentinel bit and any bits after it
+                const mask = (@as(u8, 1) << @truncate(remaining_bits)) - 1;
+                try out.*.inner.append(serialized[full_bytes] & mask);
+            }
+
+            out.*.length = bit_length;
         }
 
         pub fn isFixedSizeObject() bool {
@@ -344,7 +346,9 @@ pub fn Bitlist(comptime N: usize) type {
         /// Validates that the bitlist is correctly formed
         pub fn validateBitlist(buf: []const u8) !void {
             const byte_len = buf.len;
-            if (byte_len == 0) return;
+
+            // Empty buffer is invalid, at least sentinel bit should exist
+            if (byte_len == 0) return error.InvalidBitlistEncoding;
 
             // Maximum possible bytes in a bitlist with provided bitlimit.
             const max_bytes = ((N + 7 + 1) >> 3);


### PR DESCRIPTION
## Description

Implements bitlist-style handling for `[]bool` as mentioned in issue #42 

### Changes
  - Add SSZ serialization/deserialization for `[]bool` using bitlist encoding with sentinel bit
  - Add `InvalidBitlistEncoding` error for empty buffer validation
  - Optimize `Bitlist.sszDecode` by replacing bit-by-bit append with direct byte operations using `@clz`
  - Validate and reject empty buffers in both `Bitlist` and `[]bool` deserialization (matches FastSSZ behavior)
  - Add comprehensive edge case tests including invalid inputs, single bits, and large slices
  - Uses `@clz` for efficient sentinel bit detection